### PR TITLE
feat: Implement HTTP server for TaskManager

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -3,6 +3,7 @@ import manager.Managers;
 import model.Epic;
 import model.Subtask;
 import model.Task;
+import model.TaskStatus;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -26,16 +27,16 @@ public class Main {
         Epic epic1 = new Epic("Собрать вещи", "Собрать вещи и переехать в новую квартиру");
         int epic1Id = taskManager.createEpic(epic1);
 
-        Subtask subtask1 = new Subtask("Собрать коробки", "Нужно найти и собрать все коробки для вещей", epic1Id, Duration.ofMinutes(60), LocalDateTime.now().plusHours(2));
+        Subtask subtask1 = new Subtask("Собрать коробки", "Нужно найти и собрать все коробки для вещей", TaskStatus.NEW, epic1Id, Duration.ofMinutes(60), LocalDateTime.now().plusHours(2));
         int subtask1Id = taskManager.createSubtask(subtask1);
 
-        Subtask subtask2 = new Subtask("Упаковать книги", "Собрать все книги в коробки", epic1Id, Duration.ofMinutes(90), LocalDateTime.now().plusHours(4));
+        Subtask subtask2 = new Subtask("Упаковать книги", "Собрать все книги в коробки", TaskStatus.NEW, epic1Id, Duration.ofMinutes(90), LocalDateTime.now().plusHours(4));
         int subtask2Id = taskManager.createSubtask(subtask2);
 
         Epic epic2 = new Epic("Подготовка к отпуску", "Запланировать и подготовиться к отпуску");
         int epic2Id = taskManager.createEpic(epic2);
 
-        Subtask subtask3 = new Subtask("Купить билеты", "На самолет или поезд", epic2Id, Duration.ofMinutes(30), LocalDateTime.now().plusDays(2));
+        Subtask subtask3 = new Subtask("Купить билеты", "На самолет или поезд", TaskStatus.NEW, epic2Id, Duration.ofMinutes(30), LocalDateTime.now().plusDays(2));
         int subtask3Id = taskManager.createSubtask(subtask3);
 
 
@@ -98,6 +99,5 @@ public class Main {
         for (Task task : taskManager.getPrioritizedTasks()) {
             System.out.println(task);
         }
-
     }
 }

--- a/src/main/java/http/BaseHttpHandler.java
+++ b/src/main/java/http/BaseHttpHandler.java
@@ -17,6 +17,16 @@ public abstract class BaseHttpHandler implements HttpHandler {
         }
     }
 
+    // Новый вспомогательный метод для отправки HTTP-ответов
+    protected void sendResponse(HttpExchange h, int statusCode, String message) throws IOException {
+        byte[] resp = message.getBytes(StandardCharsets.UTF_8);
+        h.getResponseHeaders().add("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(statusCode, resp.length);
+        try (OutputStream os = h.getResponseBody()) {
+            os.write(resp);
+        }
+    }
+
     // Метод sendText из примера ТЗ для статуса 200
     protected void sendText(HttpExchange h, String text) throws IOException {
         byte[] resp = text.getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/http/BaseHttpHandler.java
+++ b/src/main/java/http/BaseHttpHandler.java
@@ -1,0 +1,89 @@
+package http;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+public abstract class BaseHttpHandler implements HttpHandler {
+
+    // Метод sendText из примера ТЗ для статуса 200
+    protected void sendText(HttpExchange h, String text) throws IOException {
+        byte[] resp = text.getBytes(StandardCharsets.UTF_8);
+        h.getResponseHeaders().add("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(200, resp.length);
+        h.getResponseBody().write(resp);
+        h.close();
+    }
+
+    // Метод sendNotFound для статуса 404
+    protected void sendNotFound(HttpExchange h, String message) throws IOException {
+        byte[] resp = message.getBytes(StandardCharsets.UTF_8);
+        h.getResponseHeaders().add("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(404, resp.length);
+        h.getResponseBody().write(resp);
+        h.close();
+    }
+
+    // Метод sendHasInteractions для статуса 406
+    protected void sendHasInteractions(HttpExchange h, String message) throws IOException {
+        byte[] resp = message.getBytes(StandardCharsets.UTF_8);
+        h.getResponseHeaders().add("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(406, resp.length);
+        h.getResponseBody().write(resp);
+        h.close();
+    }
+
+    // Метод sendNoContent для статуса 204
+    protected void sendNoContent(HttpExchange h) throws IOException {
+        h.sendResponseHeaders(204, -1);
+        h.close();
+    }
+
+    // Метод sendBadRequest для статуса 400. Для ошибок, связанных с клиентским запросом (пустое тело, некорректный JSON)
+    protected void sendBadRequest(HttpExchange h, String message) throws IOException {
+        byte[] resp = message.getBytes(StandardCharsets.UTF_8);
+        h.getResponseHeaders().add("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(400, resp.length);
+        h.getResponseBody().write(resp);
+        h.close();
+    }
+
+    // Метод sendInternalServerError для статуса 500
+    protected void sendInternalServerError(HttpExchange h, String message) throws IOException {
+        byte[] resp = message.getBytes(StandardCharsets.UTF_8);
+        h.getResponseHeaders().add("Content-Type", "application/json;charset=utf-8");
+        h.sendResponseHeaders(500, resp.length);
+        h.getResponseBody().write(resp);
+        h.close();
+    }
+
+    // Метод sendMethodNotAllowed для статуса 405
+    protected void sendMethodNotAllowed(HttpExchange exchange, String message) throws IOException {
+        byte[] response = message.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(405, response.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(response);
+        }
+    }
+
+    // Метод parseId для парсинга по id
+    protected static Optional<Integer> parseId(String query) {
+        if (query != null && query.contains("id=")) {
+            String[] params = query.split("&");
+            for (String param : params) {
+                if (param.startsWith("id=")) {
+                    try {
+                        return Optional.of(Integer.parseInt(param.substring(3)));
+                    } catch (NumberFormatException e) {
+                        return Optional.empty();
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/http/EpicsHandler.java
+++ b/src/main/java/http/EpicsHandler.java
@@ -55,6 +55,7 @@ public class EpicsHandler extends BaseHttpHandler {
             sendInternalServerError(exchange, "Ошибка сервера: " + e.getMessage());
         }
     }
+
     private void handleGetRequest(HttpExchange exchange, String query) throws IOException {
         Optional<Integer> epicIdOptional = parseId(query);
         if (epicIdOptional.isPresent()) {

--- a/src/main/java/http/EpicsHandler.java
+++ b/src/main/java/http/EpicsHandler.java
@@ -1,19 +1,16 @@
 package http;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.sun.net.httpserver.HttpExchange;
 import manager.ManagerSaveException;
 import manager.TaskManager;
 import model.Epic;
+import http.utils.GsonUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import http.utils.GsonUtils;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,12 +21,7 @@ public class EpicsHandler extends BaseHttpHandler {
 
     public EpicsHandler(TaskManager taskManager) {
         this.taskManager = taskManager;
-
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(LocalDateTime.class, new GsonUtils.LocalDateTimeAdapter());
-        gsonBuilder.registerTypeAdapter(Duration.class, new GsonUtils.DurationAdapter());
-        gsonBuilder.setPrettyPrinting();
-        this.gson = gsonBuilder.create();
+        this.gson = GsonUtils.getGson();
     }
 
     @Override
@@ -44,79 +36,90 @@ public class EpicsHandler extends BaseHttpHandler {
         try {
             switch (requestMethod) {
                 case "GET":
-                    Optional<Integer> epicIdOptional = parseId(query);
-                    if (epicIdOptional.isPresent()) {
-                        int epicId = epicIdOptional.get();
-                        Epic epic = taskManager.getEpic(epicId);
-                        if (epic != null) {
-                            String response = gson.toJson(epic);
-                            sendText(exchange, response);
-                        } else {
-                            sendNotFound(exchange, "Эпик с ID " + epicId + " не найден.");
-                        }
-                    } else {
-                        List<Epic> epics = taskManager.getEpics();
-                        String response = gson.toJson(epics);
-                        sendText(exchange, response);
-                    }
+                    handleGetRequest(exchange, query);
                     break;
                 case "POST":
-                    InputStream requestBody = exchange.getRequestBody();
-                    String body = new String(requestBody.readAllBytes(), StandardCharsets.UTF_8);
-
-                    if (body.isEmpty()) {
-                        sendBadRequest(exchange, "Тело запроса пустое.");
-                        return;
-                    }
-
-                    try {
-                        Epic epic = gson.fromJson(body, Epic.class);
-
-                        if (epic == null) {
-                            sendBadRequest(exchange, "Не удалось десериализовать эпик из JSON.");
-                            return;
-                        }
-
-                        Optional<Integer> idFromQuery = parseId(query);
-
-                        if (epic.getId() == 0) {
-                            int newId = taskManager.createEpic(epic);
-                            sendText(exchange, "Эпик создан с ID: " + newId);
-                        } else {
-                            taskManager.updateEpic(epic);
-                            sendText(exchange, "Эпик с ID " + epic.getId() + " обновлен.");
-                        }
-
-                    } catch (JsonSyntaxException e) {
-                        sendBadRequest(exchange, "Некорректный формат JSON для эпика: " + e.getMessage());
-                    } catch (ManagerSaveException e) {
-                        sendHasInteractions(exchange, e.getMessage());
-                    }
+                    handlePostRequest(exchange);
                     break;
                 case "DELETE":
-                    Optional<Integer> deleteIdOptional = parseId(query);
-                    if (deleteIdOptional.isPresent()) {
-                        int epicIdToDelete = deleteIdOptional.get();
-                        Epic epicToDelete = taskManager.getEpic(epicIdToDelete);
-                        if (epicToDelete != null) {
-                            taskManager.deleteEpic(epicIdToDelete);
-                            sendNoContent(exchange);
-                        } else {
-                            sendNotFound(exchange, "Эпик с ID " + epicIdToDelete + " не найден для удаления.");
-                        }
-                    } else {
-                        taskManager.removeAllEpics();
-                        sendNoContent(exchange);
-                        System.out.println("Все эпики удалены.");
-                    }
+                    handleDeleteRequest(exchange, query);
                     break;
                 default:
-                    sendText(exchange, "Метод " + requestMethod + " не поддерживается.");
+                    sendMethodNotAllowed(exchange, "Метод " + requestMethod + " не поддерживается.");
             }
+        } catch (InvalidIdFormatException e) {
+            sendBadRequest(exchange, e.getMessage());
         } catch (Exception e) {
             System.err.println("Ошибка при обработке запроса: " + e.getMessage());
             e.printStackTrace();
             sendInternalServerError(exchange, "Ошибка сервера: " + e.getMessage());
+        }
+    }
+    private void handleGetRequest(HttpExchange exchange, String query) throws IOException {
+        Optional<Integer> epicIdOptional = parseId(query);
+        if (epicIdOptional.isPresent()) {
+            int epicId = epicIdOptional.get();
+            Epic epic = taskManager.getEpic(epicId);
+            if (epic != null) {
+                String response = gson.toJson(epic);
+                sendText(exchange, response);
+            } else {
+                sendNotFound(exchange, "Эпик с ID " + epicId + " не найден.");
+            }
+        } else {
+            List<Epic> epics = taskManager.getEpics();
+            String response = gson.toJson(epics);
+            sendText(exchange, response);
+        }
+    }
+
+    private void handlePostRequest(HttpExchange exchange) throws IOException {
+        InputStream requestBody = exchange.getRequestBody();
+        String body = new String(requestBody.readAllBytes(), StandardCharsets.UTF_8);
+
+        if (body.isEmpty()) {
+            sendBadRequest(exchange, "Тело запроса пустое.");
+            return;
+        }
+
+        try {
+            Epic epic = gson.fromJson(body, Epic.class);
+
+            if (epic == null) {
+                sendBadRequest(exchange, "Не удалось десериализовать эпик из JSON.");
+                return;
+            }
+
+            if (epic.getId() == 0) {
+                int newId = taskManager.createEpic(epic);
+                sendText(exchange, "Эпик создан с ID: " + newId);
+            } else {
+                taskManager.updateEpic(epic);
+                sendText(exchange, "Эпик с ID " + epic.getId() + " обновлен.");
+            }
+
+        } catch (JsonSyntaxException e) {
+            sendBadRequest(exchange, "Некорректный формат JSON для эпика: " + e.getMessage());
+        } catch (ManagerSaveException e) {
+            sendHasInteractions(exchange, e.getMessage());
+        }
+    }
+
+    private void handleDeleteRequest(HttpExchange exchange, String query) throws IOException {
+        Optional<Integer> deleteIdOptional = parseId(query);
+        if (deleteIdOptional.isPresent()) {
+            int epicIdToDelete = deleteIdOptional.get();
+            Epic epicToDelete = taskManager.getEpic(epicIdToDelete);
+            if (epicToDelete != null) {
+                taskManager.deleteEpic(epicIdToDelete);
+                sendNoContent(exchange);
+            } else {
+                sendNotFound(exchange, "Эпик с ID " + epicIdToDelete + " не найден для удаления.");
+            }
+        } else {
+            taskManager.removeAllEpics();
+            sendNoContent(exchange);
+            System.out.println("Все эпики удалены.");
         }
     }
 }

--- a/src/main/java/http/EpicsHandler.java
+++ b/src/main/java/http/EpicsHandler.java
@@ -1,0 +1,122 @@
+package http;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.sun.net.httpserver.HttpExchange;
+import manager.ManagerSaveException;
+import manager.TaskManager;
+import model.Epic;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import http.utils.GsonUtils;
+import java.util.List;
+import java.util.Optional;
+
+public class EpicsHandler extends BaseHttpHandler {
+
+    private final TaskManager taskManager;
+    private final Gson gson;
+
+    public EpicsHandler(TaskManager taskManager) {
+        this.taskManager = taskManager;
+
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(LocalDateTime.class, new GsonUtils.LocalDateTimeAdapter());
+        gsonBuilder.registerTypeAdapter(Duration.class, new GsonUtils.DurationAdapter());
+        gsonBuilder.setPrettyPrinting();
+        this.gson = gsonBuilder.create();
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String requestMethod = exchange.getRequestMethod();
+        String path = exchange.getRequestURI().getPath();
+        String query = exchange.getRequestURI().getQuery();
+
+        System.out.println("Началась обработка запроса: " + requestMethod + " " + path + " с параметрами: " + query);
+
+
+        try {
+            switch (requestMethod) {
+                case "GET":
+                    Optional<Integer> epicIdOptional = parseId(query);
+                    if (epicIdOptional.isPresent()) {
+                        int epicId = epicIdOptional.get();
+                        Epic epic = taskManager.getEpic(epicId);
+                        if (epic != null) {
+                            String response = gson.toJson(epic);
+                            sendText(exchange, response);
+                        } else {
+                            sendNotFound(exchange, "Эпик с ID " + epicId + " не найден.");
+                        }
+                    } else {
+                        List<Epic> epics = taskManager.getEpics();
+                        String response = gson.toJson(epics);
+                        sendText(exchange, response);
+                    }
+                    break;
+                case "POST":
+                    InputStream requestBody = exchange.getRequestBody();
+                    String body = new String(requestBody.readAllBytes(), StandardCharsets.UTF_8);
+
+                    if (body.isEmpty()) {
+                        sendBadRequest(exchange, "Тело запроса пустое.");
+                        return;
+                    }
+
+                    try {
+                        Epic epic = gson.fromJson(body, Epic.class);
+
+                        if (epic == null) {
+                            sendBadRequest(exchange, "Не удалось десериализовать эпик из JSON.");
+                            return;
+                        }
+
+                        Optional<Integer> idFromQuery = parseId(query);
+
+                        if (epic.getId() == 0) {
+                            int newId = taskManager.createEpic(epic);
+                            sendText(exchange, "Эпик создан с ID: " + newId);
+                        } else {
+                            taskManager.updateEpic(epic);
+                            sendText(exchange, "Эпик с ID " + epic.getId() + " обновлен.");
+                        }
+
+                    } catch (JsonSyntaxException e) {
+                        sendBadRequest(exchange, "Некорректный формат JSON для эпика: " + e.getMessage());
+                    } catch (ManagerSaveException e) {
+                        sendHasInteractions(exchange, e.getMessage());
+                    }
+                    break;
+                case "DELETE":
+                    Optional<Integer> deleteIdOptional = parseId(query);
+                    if (deleteIdOptional.isPresent()) {
+                        int epicIdToDelete = deleteIdOptional.get();
+                        Epic epicToDelete = taskManager.getEpic(epicIdToDelete);
+                        if (epicToDelete != null) {
+                            taskManager.deleteEpic(epicIdToDelete);
+                            sendNoContent(exchange);
+                        } else {
+                            sendNotFound(exchange, "Эпик с ID " + epicIdToDelete + " не найден для удаления.");
+                        }
+                    } else {
+                        taskManager.removeAllEpics();
+                        sendNoContent(exchange);
+                        System.out.println("Все эпики удалены.");
+                    }
+                    break;
+                default:
+                    sendText(exchange, "Метод " + requestMethod + " не поддерживается.");
+            }
+        } catch (Exception e) {
+            System.err.println("Ошибка при обработке запроса: " + e.getMessage());
+            e.printStackTrace();
+            sendInternalServerError(exchange, "Ошибка сервера: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/http/HistoryHandler.java
+++ b/src/main/java/http/HistoryHandler.java
@@ -1,18 +1,13 @@
 package http;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import com.sun.net.httpserver.HttpExchange;
 import manager.TaskManager;
 import model.Task;
 
 import java.io.IOException;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
+import http.utils.GsonUtils;
 
 public class HistoryHandler extends BaseHttpHandler {
 
@@ -21,12 +16,7 @@ public class HistoryHandler extends BaseHttpHandler {
 
     public HistoryHandler(TaskManager taskManager) {
         this.taskManager = taskManager;
-
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter());
-        gsonBuilder.registerTypeAdapter(Duration.class, new DurationAdapter());
-        gsonBuilder.setPrettyPrinting();
-        this.gson = gsonBuilder.create();
+        this.gson = GsonUtils.getGson();
     }
 
     @Override
@@ -40,71 +30,22 @@ public class HistoryHandler extends BaseHttpHandler {
         try {
             switch (requestMethod) {
                 case "GET":
-                    List<Task> history = taskManager.getHistory();
-                    String response = gson.toJson(history);
-                    sendText(exchange, response);
+                    handleGetHistoryRequest(exchange);
                     break;
                 default:
-                    sendInternalServerError(exchange, "Метод " + requestMethod + " не поддерживается для /history.");
+                    sendMethodNotAllowed(exchange, "Метод " + requestMethod + " не поддерживается для /history.");
                     break;
             }
         } catch (Exception e) {
             System.err.println("Ошибка при обработке запроса: " + e.getMessage());
             e.printStackTrace();
-            sendMethodNotAllowed(exchange, "Ошибка сервера: " + e.getMessage());
+            sendInternalServerError(exchange, "Ошибка сервера: " + e.getMessage());
         }
     }
 
-    private static class LocalDateTimeAdapter extends com.google.gson.TypeAdapter<LocalDateTime> {
-        private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
-        @Override
-        public void write(JsonWriter out, LocalDateTime value) throws IOException {
-            if (value == null) {
-                out.nullValue();
-            } else {
-                out.value(value.format(formatter));
-            }
-        }
-
-        @Override
-        public LocalDateTime read(JsonReader in) throws IOException {
-            if (in.peek() == com.google.gson.stream.JsonToken.NULL) {
-                in.nextNull();
-                return null;
-            }
-            return LocalDateTime.parse(in.nextString(), formatter);
-        }
-    }
-
-    private static class DurationAdapter extends com.google.gson.TypeAdapter<Duration> {
-        @Override
-        public void write(JsonWriter out, Duration value) throws IOException {
-            if (value == null) {
-                out.nullValue();
-            } else {
-                out.value(value.toMinutes());
-            }
-        }
-
-        @Override
-        public Duration read(JsonReader in) throws IOException {
-            if (in.peek() == com.google.gson.stream.JsonToken.NULL) {
-                in.nextNull();
-                return null;
-            }
-            com.google.gson.stream.JsonToken peek = in.peek();
-            if (peek == com.google.gson.stream.JsonToken.NUMBER) {
-                return Duration.ofMinutes(in.nextLong());
-            } else if (peek == com.google.gson.stream.JsonToken.STRING) {
-                try {
-                    return Duration.ofMinutes(Long.parseLong(in.nextString()));
-                } catch (NumberFormatException e) {
-                    throw new IOException("Не удается выполнить parse Duration из string: " + e.getMessage());
-                }
-            } else {
-                throw new IOException("Expected NUMBER or STRING for Duration, got " + peek);
-            }
-        }
+    private void handleGetHistoryRequest(HttpExchange exchange) throws IOException {
+        List<Task> history = taskManager.getHistory();
+        String response = gson.toJson(history);
+        sendText(exchange, response);
     }
 }

--- a/src/main/java/http/HistoryHandler.java
+++ b/src/main/java/http/HistoryHandler.java
@@ -1,0 +1,110 @@
+package http;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.sun.net.httpserver.HttpExchange;
+import manager.TaskManager;
+import model.Task;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class HistoryHandler extends BaseHttpHandler {
+
+    private final TaskManager taskManager;
+    private final Gson gson;
+
+    public HistoryHandler(TaskManager taskManager) {
+        this.taskManager = taskManager;
+
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter());
+        gsonBuilder.registerTypeAdapter(Duration.class, new DurationAdapter());
+        gsonBuilder.setPrettyPrinting();
+        this.gson = gsonBuilder.create();
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String requestMethod = exchange.getRequestMethod();
+        String path = exchange.getRequestURI().getPath();
+        String query = exchange.getRequestURI().getQuery();
+
+        System.out.println("Началась обработка запроса: " + requestMethod + " " + path + " с параметрами: " + query);
+
+        try {
+            switch (requestMethod) {
+                case "GET":
+                    List<Task> history = taskManager.getHistory();
+                    String response = gson.toJson(history);
+                    sendText(exchange, response);
+                    break;
+                default:
+                    sendInternalServerError(exchange, "Метод " + requestMethod + " не поддерживается для /history.");
+                    break;
+            }
+        } catch (Exception e) {
+            System.err.println("Ошибка при обработке запроса: " + e.getMessage());
+            e.printStackTrace();
+            sendMethodNotAllowed(exchange, "Ошибка сервера: " + e.getMessage());
+        }
+    }
+
+    private static class LocalDateTimeAdapter extends com.google.gson.TypeAdapter<LocalDateTime> {
+        private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+        @Override
+        public void write(JsonWriter out, LocalDateTime value) throws IOException {
+            if (value == null) {
+                out.nullValue();
+            } else {
+                out.value(value.format(formatter));
+            }
+        }
+
+        @Override
+        public LocalDateTime read(JsonReader in) throws IOException {
+            if (in.peek() == com.google.gson.stream.JsonToken.NULL) {
+                in.nextNull();
+                return null;
+            }
+            return LocalDateTime.parse(in.nextString(), formatter);
+        }
+    }
+
+    private static class DurationAdapter extends com.google.gson.TypeAdapter<Duration> {
+        @Override
+        public void write(JsonWriter out, Duration value) throws IOException {
+            if (value == null) {
+                out.nullValue();
+            } else {
+                out.value(value.toMinutes());
+            }
+        }
+
+        @Override
+        public Duration read(JsonReader in) throws IOException {
+            if (in.peek() == com.google.gson.stream.JsonToken.NULL) {
+                in.nextNull();
+                return null;
+            }
+            com.google.gson.stream.JsonToken peek = in.peek();
+            if (peek == com.google.gson.stream.JsonToken.NUMBER) {
+                return Duration.ofMinutes(in.nextLong());
+            } else if (peek == com.google.gson.stream.JsonToken.STRING) {
+                try {
+                    return Duration.ofMinutes(Long.parseLong(in.nextString()));
+                } catch (NumberFormatException e) {
+                    throw new IOException("Не удается выполнить parse Duration из string: " + e.getMessage());
+                }
+            } else {
+                throw new IOException("Expected NUMBER or STRING for Duration, got " + peek);
+            }
+        }
+    }
+}

--- a/src/main/java/http/HttpTaskServer.java
+++ b/src/main/java/http/HttpTaskServer.java
@@ -1,17 +1,14 @@
 package http;
 
+import com.google.gson.Gson;
 import com.sun.net.httpserver.HttpServer;
+import http.utils.GsonUtils;
 import manager.Managers;
 import manager.TaskManager;
-import model.Subtask;
-import model.Task;
-import model.Epic;
-import model.TaskStatus;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.time.Duration;
-import java.time.LocalDateTime;
+
 
 public class HttpTaskServer {
 
@@ -19,27 +16,39 @@ public class HttpTaskServer {
     private final TaskManager taskManager;
     private HttpServer server;
 
+    public static Gson getGson() {
+        return GsonUtils.getGson();
+    }
+
+    public HttpTaskServer(TaskManager taskManager) throws IOException {
+        this.taskManager = taskManager;
+        this.server = HttpServer.create(new InetSocketAddress(PORT), 0);
+        initializeHandlers();
+    }
+
     public HttpTaskServer() throws IOException {
         this.taskManager = Managers.getDefault();
         this.server = HttpServer.create(new InetSocketAddress(PORT), 0);
+        initializeHandlers();
 
 
         // Временные таски для тестирования
-        int taskId1 = taskManager.createTask(new Task("Тестовая задача 1", "Описание 1", Duration.ofMinutes(60), LocalDateTime.of(2025, 7, 7, 10, 0)));
-        int taskId2 = taskManager.createTask(new Task("Тестовая задача 2", "Описание 2", Duration.ofMinutes(45), LocalDateTime.of(2025, 7, 8, 10, 0)));
+        // int taskId1 = taskManager.createTask(new Task("Тестовая задача 1", "Описание 1", Duration.ofMinutes(60), LocalDateTime.of(2025, 7, 7, 10, 0)));
+        // int taskId2 = taskManager.createTask(new Task("Тестовая задача 2", "Описание 2", Duration.ofMinutes(45), LocalDateTime.of(2025, 7, 8, 10, 0)));
 
         // Временные эпики для тестирования
-        int epicId1 = taskManager.createEpic(new Epic("Тестовый Эпик 1", "Описание эпика 1"));
-        int epicId2 = taskManager.createEpic(new Epic("Тестовый Эпик 2", "Описание эпика 2"));
+        // int epicId1 = taskManager.createEpic(new Epic("Тестовый Эпик 1", "Описание эпика 1"));
+        // int epicId2 = taskManager.createEpic(new Epic("Тестовый Эпик 2", "Описание эпика 2"));
 
         // Временные сабтаски для тестирования
-        int subtaskId1 = taskManager.createSubtask(new Subtask("Подзадача 1 Эпика 1", "Описание подзадачи 1", TaskStatus.NEW, epicId1, Duration.ofMinutes(30), LocalDateTime.of(2025, 7, 7, 12, 0)));
-        int subtaskId2 = taskManager.createSubtask(new Subtask("Подзадача 2 Эпика 1", "Описание подзадачи 2", TaskStatus.IN_PROGRESS, epicId1, Duration.ofMinutes(15), LocalDateTime.of(2025, 7, 7, 12, 30)));
-        int subtaskId3 = taskManager.createSubtask(new Subtask("Подзадача 1 Эпика 2", "Описание подзадачи 3", TaskStatus.DONE, epicId2, Duration.ofMinutes(20), LocalDateTime.of(2025, 7, 9, 9, 0)));
+        // int subtaskId1 = taskManager.createSubtask(new Subtask("Подзадача 1 Эпика 1", "Описание подзадачи 1", TaskStatus.NEW, epicId1, Duration.ofMinutes(30), LocalDateTime.of(2025, 7, 7, 12, 0)));
+        // int subtaskId2 = taskManager.createSubtask(new Subtask("Подзадача 2 Эпика 1", "Описание подзадачи 2", TaskStatus.IN_PROGRESS, epicId1, Duration.ofMinutes(15), LocalDateTime.of(2025, 7, 7, 12, 30)));
+        // int subtaskId3 = taskManager.createSubtask(new Subtask("Подзадача 1 Эпика 2", "Описание подзадачи 3", TaskStatus.DONE, epicId2, Duration.ofMinutes(20), LocalDateTime.of(2025, 7, 9, 9, 0)));
 
-        System.out.println("Тестовые данные добавлены.");
+        // System.out.println("Тестовые данные добавлены.");
+    }
 
-        // Привязываем обработчики
+    private void initializeHandlers() {
         TasksHandler tasksHandler = new TasksHandler(this.taskManager);
         this.server.createContext("/tasks", tasksHandler);
 

--- a/src/main/java/http/HttpTaskServer.java
+++ b/src/main/java/http/HttpTaskServer.java
@@ -30,22 +30,6 @@ public class HttpTaskServer {
         this.taskManager = Managers.getDefault();
         this.server = HttpServer.create(new InetSocketAddress(PORT), 0);
         initializeHandlers();
-
-
-        // Временные таски для тестирования
-        // int taskId1 = taskManager.createTask(new Task("Тестовая задача 1", "Описание 1", Duration.ofMinutes(60), LocalDateTime.of(2025, 7, 7, 10, 0)));
-        // int taskId2 = taskManager.createTask(new Task("Тестовая задача 2", "Описание 2", Duration.ofMinutes(45), LocalDateTime.of(2025, 7, 8, 10, 0)));
-
-        // Временные эпики для тестирования
-        // int epicId1 = taskManager.createEpic(new Epic("Тестовый Эпик 1", "Описание эпика 1"));
-        // int epicId2 = taskManager.createEpic(new Epic("Тестовый Эпик 2", "Описание эпика 2"));
-
-        // Временные сабтаски для тестирования
-        // int subtaskId1 = taskManager.createSubtask(new Subtask("Подзадача 1 Эпика 1", "Описание подзадачи 1", TaskStatus.NEW, epicId1, Duration.ofMinutes(30), LocalDateTime.of(2025, 7, 7, 12, 0)));
-        // int subtaskId2 = taskManager.createSubtask(new Subtask("Подзадача 2 Эпика 1", "Описание подзадачи 2", TaskStatus.IN_PROGRESS, epicId1, Duration.ofMinutes(15), LocalDateTime.of(2025, 7, 7, 12, 30)));
-        // int subtaskId3 = taskManager.createSubtask(new Subtask("Подзадача 1 Эпика 2", "Описание подзадачи 3", TaskStatus.DONE, epicId2, Duration.ofMinutes(20), LocalDateTime.of(2025, 7, 9, 9, 0)));
-
-        // System.out.println("Тестовые данные добавлены.");
     }
 
     private void initializeHandlers() {

--- a/src/main/java/http/HttpTaskServer.java
+++ b/src/main/java/http/HttpTaskServer.java
@@ -1,0 +1,78 @@
+package http;
+
+import com.sun.net.httpserver.HttpServer;
+import manager.Managers;
+import manager.TaskManager;
+import model.Subtask;
+import model.Task;
+import model.Epic;
+import model.TaskStatus;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public class HttpTaskServer {
+
+    private static final int PORT = 8080;
+    private final TaskManager taskManager;
+    private HttpServer server;
+
+    public HttpTaskServer() throws IOException {
+        this.taskManager = Managers.getDefault();
+        this.server = HttpServer.create(new InetSocketAddress(PORT), 0);
+
+
+        // Временные таски для тестирования
+        int taskId1 = taskManager.createTask(new Task("Тестовая задача 1", "Описание 1", Duration.ofMinutes(60), LocalDateTime.of(2025, 7, 7, 10, 0)));
+        int taskId2 = taskManager.createTask(new Task("Тестовая задача 2", "Описание 2", Duration.ofMinutes(45), LocalDateTime.of(2025, 7, 8, 10, 0)));
+
+        // Временные эпики для тестирования
+        int epicId1 = taskManager.createEpic(new Epic("Тестовый Эпик 1", "Описание эпика 1"));
+        int epicId2 = taskManager.createEpic(new Epic("Тестовый Эпик 2", "Описание эпика 2"));
+
+        // Временные сабтаски для тестирования
+        int subtaskId1 = taskManager.createSubtask(new Subtask("Подзадача 1 Эпика 1", "Описание подзадачи 1", TaskStatus.NEW, epicId1, Duration.ofMinutes(30), LocalDateTime.of(2025, 7, 7, 12, 0)));
+        int subtaskId2 = taskManager.createSubtask(new Subtask("Подзадача 2 Эпика 1", "Описание подзадачи 2", TaskStatus.IN_PROGRESS, epicId1, Duration.ofMinutes(15), LocalDateTime.of(2025, 7, 7, 12, 30)));
+        int subtaskId3 = taskManager.createSubtask(new Subtask("Подзадача 1 Эпика 2", "Описание подзадачи 3", TaskStatus.DONE, epicId2, Duration.ofMinutes(20), LocalDateTime.of(2025, 7, 9, 9, 0)));
+
+        System.out.println("Тестовые данные добавлены.");
+
+        // Привязываем обработчики
+        TasksHandler tasksHandler = new TasksHandler(this.taskManager);
+        this.server.createContext("/tasks", tasksHandler);
+
+        EpicsHandler epicsHandler = new EpicsHandler(this.taskManager);
+        this.server.createContext("/epics", epicsHandler);
+
+        SubtasksHandler subtasksHandler = new SubtasksHandler(this.taskManager);
+        this.server.createContext("/subtasks", subtasksHandler);
+        this.server.createContext("/subtasks/epic", subtasksHandler);
+
+        HistoryHandler historyHandler = new HistoryHandler(this.taskManager);
+        this.server.createContext("/history", historyHandler);
+    }
+
+    public void start() {
+        System.out.println("Запускаем HTTP-сервер на порту " + PORT);
+        System.out.println("http://localhost:" + PORT + "/tasks");
+        server.start();
+    }
+
+    public void stop() {
+        server.stop(0);
+        System.out.println("HTTP-сервер остановлен.");
+    }
+
+    public static void main(String[] args) {
+        try {
+            HttpTaskServer httpTaskServer = new HttpTaskServer();
+            httpTaskServer.start();
+
+        } catch (IOException e) {
+            System.err.println("Ошибка при запуске HTTP-сервера: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/http/SubtasksHandler.java
+++ b/src/main/java/http/SubtasksHandler.java
@@ -1,7 +1,6 @@
 package http;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.sun.net.httpserver.HttpExchange;
 import manager.ManagerSaveException;
@@ -12,8 +11,6 @@ import model.Subtask;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import http.utils.GsonUtils;
@@ -25,12 +22,7 @@ public class SubtasksHandler extends BaseHttpHandler {
 
     public SubtasksHandler(TaskManager taskManager) {
         this.taskManager = taskManager;
-
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(LocalDateTime.class, new GsonUtils.LocalDateTimeAdapter());
-        gsonBuilder.registerTypeAdapter(Duration.class, new GsonUtils.DurationAdapter());
-        gsonBuilder.setPrettyPrinting();
-        this.gson = gsonBuilder.create();
+        this.gson = GsonUtils.getGson();
     }
 
     @Override
@@ -43,110 +35,128 @@ public class SubtasksHandler extends BaseHttpHandler {
 
         try {
             if (path.equals("/subtasks/epic")) {
-                if ("GET".equals(requestMethod)) {
-                    Optional<Integer> epicIdOptional = parseId(query);
-                    if (epicIdOptional.isPresent()) {
-                        int epicId = epicIdOptional.get();
-                        Epic epic = taskManager.getEpic(epicId);
-                        if (epic != null) {
-                            List<Subtask> epicSubtasks = taskManager.getEpicSubtasks(epicId);
-                            String response = gson.toJson(epicSubtasks);
-                            sendText(exchange, response);
-                        } else {
-                            sendNotFound(exchange, "Эпик с ID " + epicId + " не найден.");
-                        }
-                    } else {
-                        sendBadRequest(exchange, "Требуется ID эпика для запроса подзадач.");
-                    }
-                } else {
-                    sendBadRequest(exchange, "Метод " + requestMethod + " не поддерживается для /subtasks/epic.");
-                }
+                handleEpicSubtasksRequest(exchange, requestMethod, query);
                 return;
             }
 
             switch (requestMethod) {
                 case "GET":
-                    Optional<Integer> subtaskIdOptional = parseId(query);
-                    if (subtaskIdOptional.isPresent()) {
-                        int subtaskId = subtaskIdOptional.get();
-                        Subtask subtask = taskManager.getSubtask(subtaskId);
-                        if (subtask != null) {
-                            String response = gson.toJson(subtask);
-                            sendText(exchange, response);
-                        } else {
-                            sendNotFound(exchange, "Подзадача с ID " + subtaskId + " не найдена.");
-                        }
-                    } else {
-                        List<Subtask> subtasks = taskManager.getSubtasks();
-                        String response = gson.toJson(subtasks);
-                        sendText(exchange, response);
-                    }
+                    handleGetSubtasksRequest(exchange, query);
                     break;
                 case "POST":
-                    InputStream requestBody = exchange.getRequestBody();
-                    String body = new String(requestBody.readAllBytes(), StandardCharsets.UTF_8);
-
-                    if (body.isEmpty()) {
-                        sendBadRequest(exchange, "Тело запроса пустое.");
-                        return;
-                    }
-
-                    try {
-                        Subtask subtask = gson.fromJson(body, Subtask.class);
-
-                        if (subtask == null) {
-                            sendBadRequest(exchange, "Не удалось десериализовать подзадачу из JSON.");
-                            return;
-                        }
-
-                        if (!taskManager.getEpics().stream().anyMatch(epic -> epic.getId() == subtask.getEpicId())) {
-                            sendBadRequest(exchange, "Указанный Epic с ID " + subtask.getEpicId() + " не существует.");
-                            return;
-                        }
-
-                        if (subtask.getId() == 0) {
-                            int newId = taskManager.createSubtask(subtask);
-                            sendText(exchange, "Подзадача создана с ID: " + newId);
-                        } else {
-                            Subtask existingSubtask = taskManager.getSubtask(subtask.getId());
-                            if (existingSubtask != null && existingSubtask.getEpicId() != subtask.getEpicId()) {
-                                sendBadRequest(exchange, "Нельзя изменить EpicId у существующей подзадачи.");
-                                return;
-                            }
-                            taskManager.updateSubtask(subtask);
-                            sendText(exchange, "Подзадача с ID " + subtask.getId() + " обновлена.");
-                        }
-
-                    } catch (JsonSyntaxException e) {
-                        sendBadRequest(exchange, "Некорректный формат JSON для подзадачи: " + e.getMessage());
-                    } catch (ManagerSaveException e) {
-                        sendHasInteractions(exchange, e.getMessage());
-                    }
+                    handlePostSubtaskRequest(exchange);
                     break;
                 case "DELETE":
-                    Optional<Integer> deleteIdOptional = parseId(query);
-                    if (deleteIdOptional.isPresent()) {
-                        int subtaskIdToDelete = deleteIdOptional.get();
-                        Subtask subtaskToDelete = taskManager.getSubtask(subtaskIdToDelete);
-                        if (subtaskToDelete != null) {
-                            taskManager.deleteSubtask(subtaskIdToDelete);
-                            sendNoContent(exchange);
-                        } else {
-                            sendNotFound(exchange, "Подзадача с ID " + subtaskIdToDelete + " не найдена для удаления.");
-                        }
-                    } else {
-                        taskManager.removeAllSubtasks();
-                        sendNoContent(exchange);
-                        System.out.println("Все подзадачи удалены.");
-                    }
+                    handleDeleteSubtaskRequest(exchange, query);
                     break;
                 default:
-                    sendText(exchange, "Метод " + requestMethod + " не поддерживается.");
+                    sendMethodNotAllowed(exchange, "Метод " + requestMethod + " не поддерживается.");
             }
+        } catch (InvalidIdFormatException e) {
+            sendBadRequest(exchange, e.getMessage());
         } catch (Exception e) {
             System.err.println("Ошибка при обработке запроса: " + e.getMessage());
             e.printStackTrace();
             sendInternalServerError(exchange, "Ошибка сервера: " + e.getMessage());
+        }
+    }
+
+    private void handleEpicSubtasksRequest(HttpExchange exchange, String requestMethod, String query) throws IOException {
+        if ("GET".equals(requestMethod)) {
+            Optional<Integer> epicIdOptional = parseId(query);
+            if (epicIdOptional.isPresent()) {
+                int epicId = epicIdOptional.get();
+                Epic epic = taskManager.getEpic(epicId);
+                if (epic != null) {
+                    List<Subtask> epicSubtasks = taskManager.getEpicSubtasks(epicId);
+                    String response = gson.toJson(epicSubtasks);
+                    sendText(exchange, response);
+                } else {
+                    sendNotFound(exchange, "Эпик с ID " + epicId + " не найден.");
+                }
+            } else {
+                sendBadRequest(exchange, "Требуется ID эпика для запроса подзадач.");
+            }
+        } else {
+            sendBadRequest(exchange, "Метод " + requestMethod + " не поддерживается для /subtasks/epic.");
+        }
+    }
+
+    private void handleGetSubtasksRequest(HttpExchange exchange, String query) throws IOException {
+        Optional<Integer> subtaskIdOptional = parseId(query);
+        if (subtaskIdOptional.isPresent()) {
+            int subtaskId = subtaskIdOptional.get();
+            Subtask subtask = taskManager.getSubtask(subtaskId);
+            if (subtask != null) {
+                String response = gson.toJson(subtask);
+                sendText(exchange, response);
+            } else {
+                sendNotFound(exchange, "Подзадача с ID " + subtaskId + " не найдена.");
+            }
+        } else {
+            List<Subtask> subtasks = taskManager.getSubtasks();
+            String response = gson.toJson(subtasks);
+            sendText(exchange, response);
+        }
+    }
+
+    private void handlePostSubtaskRequest(HttpExchange exchange) throws IOException {
+        InputStream requestBody = exchange.getRequestBody();
+        String body = new String(requestBody.readAllBytes(), StandardCharsets.UTF_8);
+
+        if (body.isEmpty()) {
+            sendBadRequest(exchange, "Тело запроса пустое.");
+            return;
+        }
+
+        try {
+            Subtask subtask = gson.fromJson(body, Subtask.class);
+
+            if (subtask == null) {
+                sendBadRequest(exchange, "Не удалось десериализовать подзадачу из JSON.");
+                return;
+            }
+
+            if (!taskManager.getEpics().stream().anyMatch(epic -> epic.getId() == subtask.getEpicId())) {
+                sendBadRequest(exchange, "Указанный Epic с ID " + subtask.getEpicId() + " не существует.");
+                return;
+            }
+
+            if (subtask.getId() == 0) {
+                int newId = taskManager.createSubtask(subtask);
+                sendText(exchange, "Подзадача создана с ID: " + newId);
+            } else {
+                Subtask existingSubtask = taskManager.getSubtask(subtask.getId());
+                if (existingSubtask != null && existingSubtask.getEpicId() != subtask.getEpicId()) {
+                    sendBadRequest(exchange, "Нельзя изменить EpicId у существующей подзадачи.");
+                    return;
+                }
+                taskManager.updateSubtask(subtask);
+                sendText(exchange, "Подзадача с ID " + subtask.getId() + " обновлена.");
+            }
+
+        } catch (JsonSyntaxException e) {
+            sendBadRequest(exchange, "Некорректный формат JSON для подзадачи: " + e.getMessage());
+        } catch (ManagerSaveException e) {
+            sendHasInteractions(exchange, e.getMessage());
+        }
+    }
+
+    private void handleDeleteSubtaskRequest(HttpExchange exchange, String query) throws IOException {
+        Optional<Integer> deleteIdOptional = parseId(query);
+        if (deleteIdOptional.isPresent()) {
+            int subtaskIdToDelete = deleteIdOptional.get();
+            Subtask subtaskToDelete = taskManager.getSubtask(subtaskIdToDelete);
+            if (subtaskToDelete != null) {
+                taskManager.deleteSubtask(subtaskIdToDelete);
+                sendNoContent(exchange);
+            } else {
+                sendNotFound(exchange, "Подзадача с ID " + subtaskIdToDelete + " не найдена для удаления.");
+            }
+        } else {
+            taskManager.removeAllSubtasks();
+            sendNoContent(exchange);
+            System.out.println("Все подзадачи удалены.");
         }
     }
 }

--- a/src/main/java/http/SubtasksHandler.java
+++ b/src/main/java/http/SubtasksHandler.java
@@ -1,0 +1,152 @@
+package http;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.sun.net.httpserver.HttpExchange;
+import manager.ManagerSaveException;
+import manager.TaskManager;
+import model.Epic;
+import model.Subtask;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import http.utils.GsonUtils;
+
+public class SubtasksHandler extends BaseHttpHandler {
+
+    private final TaskManager taskManager;
+    private final Gson gson;
+
+    public SubtasksHandler(TaskManager taskManager) {
+        this.taskManager = taskManager;
+
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(LocalDateTime.class, new GsonUtils.LocalDateTimeAdapter());
+        gsonBuilder.registerTypeAdapter(Duration.class, new GsonUtils.DurationAdapter());
+        gsonBuilder.setPrettyPrinting();
+        this.gson = gsonBuilder.create();
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String requestMethod = exchange.getRequestMethod();
+        String path = exchange.getRequestURI().getPath();
+        String query = exchange.getRequestURI().getQuery();
+
+        System.out.println("Началась обработка запроса: " + requestMethod + " " + path + " с параметрами: " + query);
+
+        try {
+            if (path.equals("/subtasks/epic")) {
+                if ("GET".equals(requestMethod)) {
+                    Optional<Integer> epicIdOptional = parseId(query);
+                    if (epicIdOptional.isPresent()) {
+                        int epicId = epicIdOptional.get();
+                        Epic epic = taskManager.getEpic(epicId);
+                        if (epic != null) {
+                            List<Subtask> epicSubtasks = taskManager.getEpicSubtasks(epicId);
+                            String response = gson.toJson(epicSubtasks);
+                            sendText(exchange, response);
+                        } else {
+                            sendNotFound(exchange, "Эпик с ID " + epicId + " не найден.");
+                        }
+                    } else {
+                        sendBadRequest(exchange, "Требуется ID эпика для запроса подзадач.");
+                    }
+                } else {
+                    sendBadRequest(exchange, "Метод " + requestMethod + " не поддерживается для /subtasks/epic.");
+                }
+                return;
+            }
+
+            switch (requestMethod) {
+                case "GET":
+                    Optional<Integer> subtaskIdOptional = parseId(query);
+                    if (subtaskIdOptional.isPresent()) {
+                        int subtaskId = subtaskIdOptional.get();
+                        Subtask subtask = taskManager.getSubtask(subtaskId);
+                        if (subtask != null) {
+                            String response = gson.toJson(subtask);
+                            sendText(exchange, response);
+                        } else {
+                            sendNotFound(exchange, "Подзадача с ID " + subtaskId + " не найдена.");
+                        }
+                    } else {
+                        List<Subtask> subtasks = taskManager.getSubtasks();
+                        String response = gson.toJson(subtasks);
+                        sendText(exchange, response);
+                    }
+                    break;
+                case "POST":
+                    InputStream requestBody = exchange.getRequestBody();
+                    String body = new String(requestBody.readAllBytes(), StandardCharsets.UTF_8);
+
+                    if (body.isEmpty()) {
+                        sendBadRequest(exchange, "Тело запроса пустое.");
+                        return;
+                    }
+
+                    try {
+                        Subtask subtask = gson.fromJson(body, Subtask.class);
+
+                        if (subtask == null) {
+                            sendBadRequest(exchange, "Не удалось десериализовать подзадачу из JSON.");
+                            return;
+                        }
+
+                        if (!taskManager.getEpics().stream().anyMatch(epic -> epic.getId() == subtask.getEpicId())) {
+                            sendBadRequest(exchange, "Указанный Epic с ID " + subtask.getEpicId() + " не существует.");
+                            return;
+                        }
+
+                        if (subtask.getId() == 0) {
+                            int newId = taskManager.createSubtask(subtask);
+                            sendText(exchange, "Подзадача создана с ID: " + newId);
+                        } else {
+                            Subtask existingSubtask = taskManager.getSubtask(subtask.getId());
+                            if (existingSubtask != null && existingSubtask.getEpicId() != subtask.getEpicId()) {
+                                sendBadRequest(exchange, "Нельзя изменить EpicId у существующей подзадачи.");
+                                return;
+                            }
+                            taskManager.updateSubtask(subtask);
+                            sendText(exchange, "Подзадача с ID " + subtask.getId() + " обновлена.");
+                        }
+
+                    } catch (JsonSyntaxException e) {
+                        sendBadRequest(exchange, "Некорректный формат JSON для подзадачи: " + e.getMessage());
+                    } catch (ManagerSaveException e) {
+                        sendHasInteractions(exchange, e.getMessage());
+                    }
+                    break;
+                case "DELETE":
+                    Optional<Integer> deleteIdOptional = parseId(query);
+                    if (deleteIdOptional.isPresent()) {
+                        int subtaskIdToDelete = deleteIdOptional.get();
+                        Subtask subtaskToDelete = taskManager.getSubtask(subtaskIdToDelete);
+                        if (subtaskToDelete != null) {
+                            taskManager.deleteSubtask(subtaskIdToDelete);
+                            sendNoContent(exchange);
+                        } else {
+                            sendNotFound(exchange, "Подзадача с ID " + subtaskIdToDelete + " не найдена для удаления.");
+                        }
+                    } else {
+                        taskManager.removeAllSubtasks();
+                        sendNoContent(exchange);
+                        System.out.println("Все подзадачи удалены.");
+                    }
+                    break;
+                default:
+                    sendText(exchange, "Метод " + requestMethod + " не поддерживается.");
+            }
+        } catch (Exception e) {
+            System.err.println("Ошибка при обработке запроса: " + e.getMessage());
+            e.printStackTrace();
+            sendInternalServerError(exchange, "Ошибка сервера: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/http/TasksHandler.java
+++ b/src/main/java/http/TasksHandler.java
@@ -1,0 +1,122 @@
+package http;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.sun.net.httpserver.HttpExchange;
+import manager.ManagerSaveException;
+import manager.TaskManager;
+import model.Task;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import http.utils.GsonUtils;
+import java.util.List;
+import java.util.Optional;
+
+public class TasksHandler extends BaseHttpHandler {
+
+    private final TaskManager taskManager;
+    private final Gson gson;
+
+    public TasksHandler(TaskManager taskManager) {
+        this.taskManager = taskManager;
+
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(LocalDateTime.class, new GsonUtils.LocalDateTimeAdapter());
+        gsonBuilder.registerTypeAdapter(Duration.class, new GsonUtils.DurationAdapter());
+        gsonBuilder.setPrettyPrinting();
+        this.gson = gsonBuilder.create();
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String requestMethod = exchange.getRequestMethod();
+        String path = exchange.getRequestURI().getPath();
+        String query = exchange.getRequestURI().getQuery();
+
+        System.out.println("Началась обработка запроса: " + requestMethod + " " + path + " с параметрами: " + query);
+
+        try {
+            switch (requestMethod) {
+                case "GET":
+                    Optional<Integer> taskIdOptional = parseId(query);
+                    if (taskIdOptional.isPresent()) {
+                        int taskId = taskIdOptional.get();
+                        Task task = taskManager.getTask(taskId);
+                        if (task != null) {
+                            String response = gson.toJson(task);
+                            sendText(exchange, response);
+                        } else {
+                            sendNotFound(exchange, "Задача с ID " + taskId + " не найдена.");
+                        }
+                    } else {
+                        List<Task> tasks = taskManager.getTasks();
+                        String response = gson.toJson(tasks);
+                        sendText(exchange, response);
+                    }
+                    break;
+                case "POST":
+                    InputStream requestBody = exchange.getRequestBody();
+                    String body = new String(requestBody.readAllBytes(), StandardCharsets.UTF_8);
+
+                    if (body.isEmpty()) {
+                        sendBadRequest(exchange, "Тело запроса пустое.");
+                        return;
+                    }
+
+                    try {
+                        Task task = gson.fromJson(body, Task.class);
+                        if (task == null) {
+                            sendBadRequest(exchange, "Не удалось десериализовать задачу.");
+                            return;
+                        }
+                        Optional<Integer> idFromQuery = parseId(query);
+                        if (idFromQuery.isPresent() && idFromQuery.get() != task.getId() && task.getId() != 0) {
+                            System.out.println("Предупреждение: ID в URL (" + idFromQuery.get() + ") не совпадает с ID в теле (" + task.getId() + ").");
+                        }
+                        if (task.getId() == 0) {
+                            int newId = taskManager.createTask(task);
+                            sendText(exchange, "Задача создана с ID: " + newId);
+                        } else {
+                            taskManager.updateTask(task);
+                            sendText(exchange, "Задача с ID " + task.getId() + " обновлена.");
+                        }
+
+                    } catch (JsonSyntaxException e) {
+                        sendBadRequest(exchange, "Некорректный формат JSON: " + e.getMessage());
+                    } catch (ManagerSaveException e) {
+                        sendHasInteractions(exchange, e.getMessage());
+                    }
+                    break;
+                case "DELETE":
+                    Optional<Integer> deleteIdOptional = parseId(query);
+                    if (deleteIdOptional.isPresent()) {
+                        int taskIdToDelete = deleteIdOptional.get();
+                        Task taskToDelete = taskManager.getTask(taskIdToDelete);
+                        if (taskToDelete != null) {
+                            taskManager.deleteTask(taskIdToDelete);
+                            sendNoContent(exchange);
+                        } else {
+                            sendNotFound(exchange, "Задача с ID " + taskIdToDelete + " не найдена для удаления.");
+                        }
+                    } else {
+                        // Если ID не указан, то удалятся все задачи
+                        taskManager.removeAllTasks();
+                        sendNoContent(exchange);
+                        System.out.println("Все задачи удалены.");
+                    }
+                    break;
+                default:
+                    sendText(exchange, "Метод " + requestMethod + " не поддерживается.");
+            }
+        } catch (Exception e) {
+            System.err.println("Ошибка при обработке запроса: " + e.getMessage());
+            e.printStackTrace();
+            sendBadRequest(exchange, "Ошибка сервера: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/http/utils/GsonUtils.java
+++ b/src/main/java/http/utils/GsonUtils.java
@@ -12,7 +12,8 @@ import java.time.format.DateTimeFormatter;
 
 public class GsonUtils { // Создала отдельным классом, чтобы не дублировать во всех Handler'ах
 
-    private GsonUtils() {}
+    private GsonUtils() {
+    }
 
     // Метод для получения настроенного Gson
     public static Gson getGson() {
@@ -76,3 +77,4 @@ public class GsonUtils { // Создала отдельным классом, ч
         }
     }
 }
+

--- a/src/main/java/http/utils/GsonUtils.java
+++ b/src/main/java/http/utils/GsonUtils.java
@@ -1,0 +1,78 @@
+package http.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class GsonUtils { // Создала отдельным классом, чтобы не дублировать во всех Handler'ах
+
+    private GsonUtils() {}
+
+    // Метод для получения настроенного Gson
+    public static Gson getGson() {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter());
+        gsonBuilder.registerTypeAdapter(Duration.class, new DurationAdapter());
+        gsonBuilder.setPrettyPrinting();
+        return gsonBuilder.create();
+    }
+
+    public static class LocalDateTimeAdapter extends com.google.gson.TypeAdapter<LocalDateTime> {
+        private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+        @Override
+        public void write(JsonWriter out, LocalDateTime value) throws IOException {
+            if (value == null) {
+                out.nullValue();
+            } else {
+                out.value(value.format(formatter));
+            }
+        }
+
+        @Override
+        public LocalDateTime read(JsonReader in) throws IOException {
+            if (in.peek() == com.google.gson.stream.JsonToken.NULL) {
+                in.nextNull();
+                return null;
+            }
+            return LocalDateTime.parse(in.nextString(), formatter);
+        }
+    }
+
+    public static class DurationAdapter extends com.google.gson.TypeAdapter<Duration> {
+        @Override
+        public void write(JsonWriter out, Duration value) throws IOException {
+            if (value == null) {
+                out.nullValue();
+            } else {
+                out.value(value.toMinutes());
+            }
+        }
+
+        @Override
+        public Duration read(JsonReader in) throws IOException {
+            if (in.peek() == com.google.gson.stream.JsonToken.NULL) {
+                in.nextNull();
+                return null;
+            }
+            com.google.gson.stream.JsonToken peek = in.peek();
+            if (peek == com.google.gson.stream.JsonToken.NUMBER) {
+                return Duration.ofMinutes(in.nextLong());
+            } else if (peek == com.google.gson.stream.JsonToken.STRING) {
+                try {
+                    return Duration.ofMinutes(Long.parseLong(in.nextString()));
+                } catch (NumberFormatException e) {
+                    throw new IOException("Не удается выполнить parse Duration из string: " + e.getMessage());
+                }
+            } else {
+                throw new IOException("Expected NUMBER or STRING for Duration, got " + peek);
+            }
+        }
+    }
+}

--- a/src/main/java/manager/FileBackedTaskManager.java
+++ b/src/main/java/manager/FileBackedTaskManager.java
@@ -49,7 +49,7 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
     }
 
     private String taskToString(Task task) {
-        StringBuilder csvLineBuilder = new StringBuilder(); // Переименовала sb в csvLineBuilder
+        StringBuilder csvLineBuilder = new StringBuilder();
 
         csvLineBuilder.append(task.getId()).append(",");
 

--- a/src/main/java/manager/FileBackedTaskManager.java
+++ b/src/main/java/manager/FileBackedTaskManager.java
@@ -6,18 +6,17 @@ import model.Task;
 import model.TaskStatus;
 import model.TaskType;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.Collection;
-import java.util.stream.Stream;
-
 
 public class FileBackedTaskManager extends InMemoryTaskManager {
 
@@ -27,7 +26,7 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
         this.file = file;
     }
 
-    private void save() throws ManagerSaveException {
+    protected void save() {
         try (FileWriter writer = new FileWriter(file)) {
             writer.write("id,type,name,status,description,startTime,duration,epic\n");
 
@@ -43,6 +42,8 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
                 writer.write(taskToString(subtask) + "\n");
             }
 
+            writer.write("\n");
+            writer.write(historyToString(getHistory()));
         } catch (IOException e) {
             throw new ManagerSaveException("Ошибка сохранения задач в файл: " + file.getName(), e);
         }
@@ -67,10 +68,14 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
         csvLineBuilder.append(",");
         if (task.getStartTime() != null) {
             csvLineBuilder.append(task.getStartTime());
+        } else {
+            csvLineBuilder.append("");
         }
         csvLineBuilder.append(",");
         if (task.getDuration() != null) {
             csvLineBuilder.append(task.getDuration().toMinutes());
+        } else {
+            csvLineBuilder.append("");
         }
 
         if (task instanceof Subtask) {
@@ -83,43 +88,50 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
 
     public static FileBackedTaskManager loadFromFile(File file) throws ManagerSaveException {
         FileBackedTaskManager manager = new FileBackedTaskManager(file);
+        String historyLine = null;
 
         if (!file.exists()) {
             return manager;
         }
 
-        try {
-            String content = Files.readString(file.toPath());
-            String[] lines = content.split("\n");
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+            br.readLine();
 
-            if (lines.length > 1) {
-                for (int i = 1; i < lines.length; i++) {
-                    String line = lines[i];
-                    if (line.isBlank()) continue;
+            String line;
+            List<String> taskLines = new ArrayList<>();
+            boolean readingHistory = false;
 
-                    Optional<Task> optionalTask = fromString(line);
-                    if (optionalTask.isEmpty()) {
-                        System.err.println("Пропущена некорректная строка при загрузке: " + line);
-                        continue;
-                    }
-                    Task task = optionalTask.get();
-
-                    if (task instanceof Epic) {
-                        manager.epics.put(task.getId(), (Epic) task);
-                    } else if (task instanceof Subtask) {
-                        manager.subtasks.put(task.getId(), (Subtask) task);
-                    } else {
-                        manager.tasks.put(task.getId(), task);
-                    }
+            while ((line = br.readLine()) != null) {
+                if (line.isBlank()) {
+                    readingHistory = true;
+                    continue;
+                }
+                if (readingHistory) {
+                    historyLine = line;
+                } else {
+                    taskLines.add(line);
                 }
             }
 
-            int maxId = Stream.of(manager.tasks.keySet(), manager.epics.keySet(), manager.subtasks.keySet())
-                    .flatMap(Set::stream)
-                    .max(Integer::compareTo)
-                    .orElse(0);
+            for (String taskLine : taskLines) {
+                Optional<Task> optionalTask = fromString(taskLine);
+                if (optionalTask.isEmpty()) {
+                    System.err.println("Пропущена некорректная строка при загрузке: " + taskLine);
+                    continue;
+                }
+                Task task = optionalTask.get();
 
-            manager.idCounter = maxId;
+                if (task instanceof Epic) {
+                    manager.epics.put(task.getId(), (Epic) task);
+                } else if (task instanceof Subtask) {
+                    manager.subtasks.put(task.getId(), (Subtask) task);
+                } else {
+                    manager.tasks.put(task.getId(), task);
+                }
+                if (task.getId() >= manager.idCounter) {
+                    manager.idCounter = task.getId() + 1;
+                }
+            }
 
             for (Subtask subtask : manager.subtasks.values()) {
                 Epic epic = manager.epics.get(subtask.getEpicId());
@@ -136,12 +148,18 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
                 manager.calculateEpicTimesAndStatus(epic);
             }
 
-            manager.prioritizedTasks.clear();
-            Stream.of(manager.tasks.values(), manager.epics.values(), manager.subtasks.values())
-                    .flatMap(Collection::stream)
-                    .filter(task -> task != null && task.getStartTime() != null)
-                    .forEach(manager.prioritizedTasks::add);
-
+            if (historyLine != null && !historyLine.trim().isEmpty()) {
+                List<Integer> idsInHistory = historyFromString(historyLine);
+                for (Integer id : idsInHistory) {
+                    if (manager.tasks.containsKey(id)) {
+                        manager.getTask(id);
+                    } else if (manager.epics.containsKey(id)) {
+                        manager.getEpic(id);
+                    } else if (manager.subtasks.containsKey(id)) {
+                        manager.getSubtask(id);
+                    }
+                }
+            }
 
         } catch (IOException e) {
             throw new ManagerSaveException("Ошибка загрузки задач из файла: " + file.getName(), e);
@@ -153,6 +171,7 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
     private static Optional<Task> fromString(String value) {
         String[] parts = value.split(",");
         if (parts.length < 5) {
+            System.err.println("Некорректная строка (слишком короткая): " + value);
             return Optional.empty();
         }
 
@@ -170,7 +189,6 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
                 System.err.println("Ошибка парсинга статуса в строке: " + value + " - " + e.getMessage());
                 return Optional.empty();
             }
-
 
             LocalDateTime startTime = null;
             if (parts.length > 5 && !parts[5].isEmpty()) {
@@ -192,7 +210,6 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
                     return Optional.empty();
                 }
             }
-
 
             switch (type) {
                 case TASK:
@@ -229,15 +246,42 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
                     return Optional.empty();
             }
         } catch (NumberFormatException e) {
-            System.err.println("Ошибка парсинга ID в строке: " + value + " - " + e.getMessage());
+            System.err.println("Ошибка парсинга числовых полей в строке: " + value + " - " + e.getMessage());
             return Optional.empty();
         } catch (IllegalArgumentException e) {
-            System.err.println("Ошибка парсинга типа задачи в строке: " + value + " - " + e.getMessage());
+            System.err.println("Ошибка парсинга типа или статуса задачи в строке: " + value + " - " + e.getMessage());
             return Optional.empty();
         } catch (ArrayIndexOutOfBoundsException e) {
             System.err.println("Некорректный формат строки: пропущены поля: " + value + " - " + e.getMessage());
             return Optional.empty();
         }
+    }
+
+    private String historyToString(List<Task> history) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < history.size(); i++) {
+            sb.append(history.get(i).getId());
+            if (i < history.size() - 1) {
+                sb.append(",");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static List<Integer> historyFromString(String value) {
+        List<Integer> ids = new ArrayList<>();
+        if (value == null || value.trim().isEmpty()) {
+            return ids;
+        }
+        String[] idStrings = value.split(",");
+        for (String idStr : idStrings) {
+            try {
+                ids.add(Integer.parseInt(idStr.trim()));
+            } catch (NumberFormatException e) {
+                System.err.println("Ошибка парсинга ID в строке истории: " + idStr + " - " + e.getMessage());
+            }
+        }
+        return ids;
     }
 
     @Override
@@ -317,5 +361,26 @@ public class FileBackedTaskManager extends InMemoryTaskManager {
     public void removeAllSubtasks() {
         super.removeAllSubtasks();
         save();
+    }
+
+    @Override
+    public Task getTask(int id) {
+        Task task = super.getTask(id);
+        save();
+        return task;
+    }
+
+    @Override
+    public Epic getEpic(int id) {
+        Epic epic = super.getEpic(id);
+        save();
+        return epic;
+    }
+
+    @Override
+    public Subtask getSubtask(int id) {
+        Subtask subtask = super.getSubtask(id);
+        save();
+        return subtask;
     }
 }

--- a/src/main/java/manager/InMemoryHistoryManager.java
+++ b/src/main/java/manager/InMemoryHistoryManager.java
@@ -14,7 +14,7 @@ public class InMemoryHistoryManager implements HistoryManager {
     private Node tail;
 
     private static class Node {
-        private Task task; // Добавила модификаторы доступа
+        private Task task;
         private Node prev;
         private Node next;
 

--- a/src/main/java/manager/InMemoryTaskManager.java
+++ b/src/main/java/manager/InMemoryTaskManager.java
@@ -16,9 +16,13 @@ public class InMemoryTaskManager implements TaskManager {
     protected final Map<Integer, Epic> epics;
     protected final Map<Integer, Subtask> subtasks;
     protected int idCounter;
-    private final HistoryManager historyManager;
+    protected  final HistoryManager historyManager;
     protected final Set<Task> prioritizedTasks;
 
+
+    public HistoryManager getHistoryManager() {
+        return historyManager;
+    }
 
     public InMemoryTaskManager() {
         this.tasks = new HashMap<>();
@@ -268,12 +272,10 @@ public class InMemoryTaskManager implements TaskManager {
             if (epic != null) {
                 epic.removeSubtaskId(id);
                 calculateEpicTimesAndStatus(epic);
-                // Обнаружена проблема! epic.getStartTime() может стать null
-                // Проверяю, что Epic корректно удаляется/добавляется в prioritizedTasks
                 if (epic.getStartTime() == null) {
                     prioritizedTasks.remove(epic);
                 } else {
-                    prioritizedTasks.remove(epic); // Изменения
+                    prioritizedTasks.remove(epic);
                     prioritizedTasks.add(epic);
                 }
             }

--- a/src/main/java/model/Epic.java
+++ b/src/main/java/model/Epic.java
@@ -5,26 +5,29 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class Epic extends Task {
-    private final List<Integer> subtaskIds;
-    private LocalDateTime endTime;
+    private List<Integer> subtaskIds = new ArrayList<>();
+    private LocalDateTime endTime = null;
 
     public Epic(String name, String description) {
         super(name, description);
-        this.subtaskIds = new ArrayList<>();
         this.status = TaskStatus.NEW;
         this.duration = Duration.ZERO;
         this.startTime = null;
-        this.endTime = null;
     }
 
     public Epic(String name, String description, int id, TaskStatus status) {
         super(name, description, id, status);
-        this.subtaskIds = new ArrayList<>();
         this.duration = Duration.ZERO;
         this.startTime = null;
-        this.endTime = null;
+    }
+
+    // Это для Gson, чтобы не было больше null. Иначе NullPointerException заставляет дёргаться мой глаз
+    public Epic() {
+        super(null, null); // Вызов конструктора "родителя"
+        this.status = TaskStatus.NEW;
+        this.duration = Duration.ZERO;
+        this.startTime = null;
     }
 
 
@@ -67,7 +70,6 @@ public class Epic extends Task {
         this.startTime = startTime;
     }
 
-
     @Override
     public String toString() {
         return "Epic{" +
@@ -81,5 +83,4 @@ public class Epic extends Task {
                 ", endTime=" + endTime +
                 '}';
     }
-
 }

--- a/src/main/java/model/Subtask.java
+++ b/src/main/java/model/Subtask.java
@@ -3,36 +3,36 @@ package model;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-
 public class Subtask extends Task {
-    private final int epicId;
+    private int epicId;
 
-
-    public Subtask(String name, String description, int epicId, Duration duration, LocalDateTime startTime) {
+    public Subtask(String name, String description, TaskStatus status, int epicId, Duration duration, LocalDateTime startTime) {
         super(name, description, duration, startTime);
-        this.epicId = epicId;
-    }
-
-    public Subtask(String name, String description, int epicId) {
-        super(name, description);
+        this.status = status;
         this.epicId = epicId;
     }
 
     public Subtask(String name, String description, int id, TaskStatus status, int epicId, Duration duration, LocalDateTime startTime) {
-        super(name, description, id, status, duration, startTime);
+        super(name, description, id, status, duration, startTime); // Вызов конструктора Task с id, временем и длительностью
         this.epicId = epicId;
     }
 
-    public Subtask(String name, String description, int id, TaskStatus status, int epicId) {
-        super(name, description, id, status);
-        this.epicId = epicId;
+    // Исправила конструктор для Gson
+    public Subtask() {
+        super(null, null);
+        this.status = TaskStatus.NEW;
+        this.epicId = 0;
+        this.duration = Duration.ZERO;
+        this.startTime = null;
     }
-
 
     public int getEpicId() {
         return epicId;
     }
 
+    public void setEpicId(int epicId) {
+        this.epicId = epicId;
+    }
 
     @Override
     public String toString() {
@@ -47,5 +47,4 @@ public class Subtask extends Task {
                 ", endTime=" + getEndTime() +
                 '}';
     }
-
 }

--- a/src/main/java/model/Subtask.java
+++ b/src/main/java/model/Subtask.java
@@ -13,7 +13,7 @@ public class Subtask extends Task {
     }
 
     public Subtask(String name, String description, int id, TaskStatus status, int epicId, Duration duration, LocalDateTime startTime) {
-        super(name, description, id, status, duration, startTime); // Вызов конструктора Task с id, временем и длительностью
+        super(name, description, id, status, duration, startTime);
         this.epicId = epicId;
     }
 

--- a/test/java/http/HttpTaskServerEpicsTest.java
+++ b/test/java/http/HttpTaskServerEpicsTest.java
@@ -1,0 +1,264 @@
+package http;
+
+import com.google.gson.Gson;
+import manager.InMemoryTaskManager;
+import manager.TaskManager;
+import model.Epic;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HttpTaskServerEpicsTest {
+
+    private TaskManager taskManager;
+    private HttpTaskServer taskServer;
+    private Gson gson;
+    private HttpClient client;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        taskManager = new InMemoryTaskManager();
+        taskServer = new HttpTaskServer(taskManager);
+        gson = HttpTaskServer.getGson();
+        client = HttpClient.newHttpClient();
+        taskServer.start();
+
+        taskManager.removeAllTasks();
+        taskManager.removeAllEpics();
+        taskManager.removeAllSubtasks();
+    }
+
+    @AfterEach
+    public void shutDown() {
+        taskServer.stop();
+    }
+
+    @Test
+    void testCreateEpic() throws IOException, InterruptedException {
+        Epic epic = new Epic("Test Epic 1", "Description 1");
+        String epicJson = gson.toJson(epic);
+
+        URI url = URI.create("http://localhost:8080/epics");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(epicJson))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK status for epic creation (current handler returns 200).");
+        assertTrue(response.body().contains("Эпик создан с ID:"), "Response body should indicate epic creation.");
+
+        List<Epic> epicsFromManager = taskManager.getEpics();
+        assertNotNull(epicsFromManager, "Epics list should not be null.");
+        assertEquals(1, epicsFromManager.size(), "Expected 1 epic in manager after creation.");
+        assertEquals("Test Epic 1", epicsFromManager.get(0).getName(), "Epic name mismatch.");
+        assertEquals(epic.getDescription(), epicsFromManager.get(0).getDescription(), "Epic description mismatch.");
+    }
+
+    @Test
+    void testUpdateEpic() throws IOException, InterruptedException {
+        Epic originalEpic = new Epic("Original Epic", "Original Description");
+        int epicId = taskManager.createEpic(originalEpic);
+
+        Epic updatedEpic = new Epic("Updated Epic", "Updated Description");
+        updatedEpic.setId(epicId);
+        String updatedEpicJson = gson.toJson(updatedEpic);
+
+        URI url = URI.create("http://localhost:8080/epics");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(updatedEpicJson))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK status for epic update (current handler returns 200).");
+        assertTrue(response.body().contains("Эпик с ID " + epicId + " обновлен."), "Response body should indicate epic update.");
+
+        Epic epicFromManager = taskManager.getEpic(epicId);
+        assertNotNull(epicFromManager, "Updated epic should not be null.");
+        assertEquals("Updated Epic", epicFromManager.getName(), "Epic name should be updated.");
+        assertEquals("Updated Description", epicFromManager.getDescription(), "Epic description should be updated.");
+    }
+
+    @Test
+    void testCreateEpicInvalidJson() throws IOException, InterruptedException {
+        String invalidJson = "{invalid json";
+
+        URI url = URI.create("http://localhost:8080/epics");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(invalidJson))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid JSON.");
+        assertTrue(response.body().contains("Некорректный формат JSON для эпика"), "Response body should indicate JSON format error.");
+    }
+
+    @Test
+    void testCreateEpicEmptyBody() throws IOException, InterruptedException {
+        String emptyBody = "";
+
+        URI url = URI.create("http://localhost:8080/epics");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(emptyBody))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for empty body.");
+        assertTrue(response.body().contains("Тело запроса пустое."), "Response body should indicate empty body error.");
+    }
+
+    @Test
+    void testGetAllEpics() throws IOException, InterruptedException {
+        taskManager.createEpic(new Epic("Epic 1", "Desc 1"));
+        taskManager.createEpic(new Epic("Epic 2", "Desc 2"));
+
+        URI url = URI.create("http://localhost:8080/epics");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK status for getting all epics.");
+
+        List<Epic> epics = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Epic>>(){}.getType());
+
+        assertNotNull(epics, "Epics list should not be null in response.");
+        assertEquals(2, epics.size(), "Expected 2 epics in response.");
+        assertEquals("Epic 1", epics.get(0).getName());
+        assertEquals("Epic 2", epics.get(1).getName());
+    }
+
+    @Test
+    void testGetEpicByIdValid() throws IOException, InterruptedException {
+        Epic epic = new Epic("Epic for ID", "Description for ID");
+        int epicId = taskManager.createEpic(epic);
+
+        URI url = URI.create("http://localhost:8080/epics?id=" + epicId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK status for getting epic by ID.");
+
+        Epic receivedEpic = gson.fromJson(response.body(), Epic.class);
+
+        assertNotNull(receivedEpic, "Received epic should not be null.");
+        assertEquals(epicId, receivedEpic.getId(), "Epic ID mismatch.");
+        assertEquals("Epic for ID", receivedEpic.getName(), "Epic name mismatch.");
+    }
+
+    @Test
+    void testGetEpicByIdNonExistent() throws IOException, InterruptedException {
+        int nonExistentId = 999;
+        URI url = URI.create("http://localhost:8080/epics?id=" + nonExistentId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(404, response.statusCode(), "Expected 404 Not Found for non-existent epic ID.");
+        assertTrue(response.body().contains("Эпик с ID " + nonExistentId + " не найден."), "Response body should indicate epic not found.");
+    }
+
+    @Test
+    void testGetEpicByIdInvalidFormat() throws IOException, InterruptedException {
+        URI url = URI.create("http://localhost:8080/epics?id=abc");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid ID format (current handler logic).");
+        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+    }
+
+    @Test
+    void testDeleteEpicByIdValid() throws IOException, InterruptedException {
+        Epic epic = new Epic("Epic to Delete", "Description");
+        int epicId = taskManager.createEpic(epic);
+
+        URI url = URI.create("http://localhost:8080/epics?id=" + epicId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .DELETE()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(204, response.statusCode(), "Expected 204 No Content for successful deletion.");
+        assertNull(taskManager.getEpic(epicId), "Epic should be deleted from manager.");
+    }
+
+    @Test
+    void testDeleteEpicByIdNonExistent() throws IOException, InterruptedException {
+        int nonExistentId = 999;
+        URI url = URI.create("http://localhost:8080/epics?id=" + nonExistentId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .DELETE()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(404, response.statusCode(), "Expected 404 Not Found for deleting non-existent epic.");
+        assertTrue(response.body().contains("Эпик с ID " + nonExistentId + " не найден для удаления."), "Response body should indicate epic not found.");
+    }
+
+    @Test
+    void testDeleteEpicByIdInvalidFormat() throws IOException, InterruptedException {
+        URI url = URI.create("http://localhost:8080/epics?id=xyz");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .DELETE()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid ID format (current handler logic).");
+        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+    }
+
+    @Test
+    void testDeleteAllEpics() throws IOException, InterruptedException {
+        taskManager.createEpic(new Epic("Epic 1", "Desc 1"));
+        taskManager.createEpic(new Epic("Epic 2", "Desc 2"));
+
+        URI url = URI.create("http://localhost:8080/epics");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .DELETE()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(204, response.statusCode(), "Expected 204 No Content for deleting all epics.");
+        assertTrue(taskManager.getEpics().isEmpty(), "All epics should be deleted from manager.");
+    }
+}

--- a/test/java/http/HttpTaskServerEpicsTest.java
+++ b/test/java/http/HttpTaskServerEpicsTest.java
@@ -195,8 +195,8 @@ public class HttpTaskServerEpicsTest {
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid ID format (current handler logic).");
-        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid ID format.");
+        assertTrue(response.body().contains("Некорректный формат ID: 'abc' не является числом."), "Response body should indicate invalid ID format error.");
     }
 
     @Test
@@ -241,8 +241,8 @@ public class HttpTaskServerEpicsTest {
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid ID format (current handler logic).");
-        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid ID format.");
+        assertTrue(response.body().contains("Некорректный формат ID: 'xyz' не является числом."), "Response body should indicate invalid ID format error.");
     }
 
     @Test

--- a/test/java/http/HttpTaskServerHistoryTest.java
+++ b/test/java/http/HttpTaskServerHistoryTest.java
@@ -1,0 +1,189 @@
+package http;
+
+import com.google.gson.Gson;
+import manager.InMemoryTaskManager;
+import manager.TaskManager;
+import model.Epic;
+import model.Subtask;
+import model.Task;
+import model.TaskStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HttpTaskServerHistoryTest {
+
+    private TaskManager taskManager;
+    private HttpTaskServer taskServer;
+    private Gson gson;
+    private HttpClient client;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        taskManager = new InMemoryTaskManager();
+        taskServer = new HttpTaskServer(taskManager);
+        gson = HttpTaskServer.getGson();
+        client = HttpClient.newHttpClient();
+        taskServer.start();
+
+        taskManager.removeAllTasks();
+        taskManager.removeAllEpics();
+        taskManager.removeAllSubtasks();
+    }
+
+    @AfterEach
+    public void shutDown() {
+        taskServer.stop();
+    }
+
+    @Test
+    void testGetEmptyHistory() throws IOException, InterruptedException {
+        URI url = URI.create("http://localhost:8080/history");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK for history endpoint.");
+        List<Task> history = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Task>>(){}.getType());
+
+        assertNotNull(history, "History list should not be null.");
+        assertTrue(history.isEmpty(), "History should be empty when no tasks have been viewed.");
+    }
+
+    @Test
+    void testGetHistoryAfterViewingTasks() throws IOException, InterruptedException {
+        Task task1 = new Task("Task 1", "Desc 1", Duration.ofMinutes(30), LocalDateTime.now());
+        Task task2 = new Task("Task 2", "Desc 2", Duration.ofMinutes(60), LocalDateTime.now().plusHours(1));
+        task2.setStatus(TaskStatus.IN_PROGRESS);
+
+        Epic epic1 = new Epic("Epic 1", "Epic Desc 1");
+        int taskId1 = taskManager.createTask(task1);
+        int taskId2 = taskManager.createTask(task2);
+        int epicId1 = taskManager.createEpic(epic1);
+
+        taskManager.getTask(taskId1);
+        taskManager.getEpic(epicId1);
+        taskManager.getTask(taskId2);
+
+        URI url = URI.create("http://localhost:8080/history");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK for history endpoint.");
+        List<Task> history = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Task>>(){}.getType());
+
+        assertNotNull(history, "History list should not be null.");
+        assertEquals(3, history.size(), "Expected 3 items in history.");
+
+        assertEquals(taskId1, history.get(0).getId(), "First viewed task should be first in history.");
+        assertEquals(epicId1, history.get(1).getId(), "Second viewed epic should be second in history.");
+        assertEquals(taskId2, history.get(2).getId(), "Third viewed task should be third in history.");
+    }
+
+    @Test
+    void testHistoryOrderOnRevisit() throws IOException, InterruptedException {
+        Task task1 = new Task("Task 1", "Desc 1", Duration.ofMinutes(30), LocalDateTime.now());
+        Task task2 = new Task("Task 2", "Desc 2", Duration.ofMinutes(60), LocalDateTime.now().plusHours(1));
+        task2.setStatus(TaskStatus.IN_PROGRESS); // Если статус не NEW по умолчанию
+        int taskId1 = taskManager.createTask(task1);
+        int taskId2 = taskManager.createTask(task2);
+
+        taskManager.getTask(taskId1);
+        taskManager.getTask(taskId2);
+        taskManager.getTask(taskId1);
+
+        URI url = URI.create("http://localhost:8080/history");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 OK for history endpoint.");
+
+        List<Task> history = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Task>>(){}.getType());
+
+        assertNotNull(history, "History list should not be null.");
+        assertEquals(2, history.size(), "Expected 2 items in history (T1, T2).");
+        assertEquals(taskId2, history.get(0).getId(), "Task 2 should be first in history.");
+        assertEquals(taskId1, history.get(1).getId(), "Task 1 should be last in history after re-view.");
+    }
+
+    @Test
+    void testHistoryAfterDeletingTask() throws IOException, InterruptedException {
+        Task task1 = new Task("Task 1", "Desc 1", Duration.ofMinutes(30), LocalDateTime.now());
+        Task task2 = new Task("Task 2", "Desc 2", Duration.ofMinutes(60), LocalDateTime.now().plusHours(1));
+        task2.setStatus(TaskStatus.IN_PROGRESS);
+        int taskId1 = taskManager.createTask(task1);
+        int taskId2 = taskManager.createTask(task2);
+
+        taskManager.getTask(taskId1);
+        taskManager.getTask(taskId2);
+
+        taskManager.deleteTask(taskId1);
+
+        URI url = URI.create("http://localhost:8080/history");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 OK for history endpoint.");
+
+        List<Task> history = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Task>>(){}.getType());
+
+        assertNotNull(history, "History list should not be null.");
+        assertEquals(1, history.size(), "Expected 1 item in history after deletion.");
+        assertEquals(taskId2, history.get(0).getId(), "Only Task 2 should remain in history.");
+    }
+
+    @Test
+    void testHistoryAfterDeletingEpicAndSubtasks() throws IOException, InterruptedException {
+        Epic epic = new Epic("Test Epic", "Description");
+        int createdEpicId = taskManager.createEpic(epic);
+
+        Subtask subtask1 = new Subtask("Subtask 1", "Desc 1", TaskStatus.NEW, createdEpicId, Duration.ofMinutes(10), LocalDateTime.now().plusDays(1));
+        Subtask subtask2 = new Subtask("Subtask 2", "Desc 2", TaskStatus.NEW, createdEpicId, Duration.ofMinutes(15), LocalDateTime.now().plusDays(2));
+        int subtaskId1 = taskManager.createSubtask(subtask1);
+        int subtaskId2 = taskManager.createSubtask(subtask2);
+
+        taskManager.getEpic(createdEpicId);
+        taskManager.getSubtask(subtaskId1);
+        taskManager.getSubtask(subtaskId2);
+
+        taskManager.deleteEpic(createdEpicId);
+
+        URI url = URI.create("http://localhost:8080/history");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 OK for history endpoint.");
+
+        List<Task> history = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Task>>(){}.getType());
+
+        assertNotNull(history, "History list should not be null.");
+        assertTrue(history.isEmpty(), "History should be empty after deleting epic and its subtasks.");
+    }
+}

--- a/test/java/http/HttpTaskServerSubtasksTest.java
+++ b/test/java/http/HttpTaskServerSubtasksTest.java
@@ -1,0 +1,380 @@
+package http;
+
+import com.google.gson.Gson;
+import manager.InMemoryTaskManager;
+import manager.TaskManager;
+import model.Epic;
+import model.Subtask;
+import model.TaskStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HttpTaskServerSubtasksTest {
+
+    private TaskManager taskManager;
+    private HttpTaskServer taskServer;
+    private Gson gson;
+    private HttpClient client;
+    private int epicId;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        taskManager = new InMemoryTaskManager();
+        taskServer = new HttpTaskServer(taskManager);
+        gson = HttpTaskServer.getGson();
+        client = HttpClient.newHttpClient();
+        taskServer.start();
+
+        taskManager.removeAllTasks();
+        taskManager.removeAllEpics();
+        taskManager.removeAllSubtasks();
+
+        Epic epic = new Epic("Parent Epic", "Description");
+        epicId = taskManager.createEpic(epic);
+    }
+
+    @AfterEach
+    public void shutDown() {
+        taskServer.stop();
+    }
+
+    @Test
+    void testCreateSubtask() throws IOException, InterruptedException {
+        Subtask subtask = new Subtask("Test Subtask 1", "Desc 1", TaskStatus.NEW, epicId, Duration.ofMinutes(30), LocalDateTime.now());
+        String subtaskJson = gson.toJson(subtask);
+
+        URI url = URI.create("http://localhost:8080/subtasks");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(subtaskJson))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK for subtask creation (current handler returns 200).");
+        assertTrue(response.body().contains("Подзадача создана с ID:"), "Response body should indicate subtask creation.");
+
+        List<Subtask> subtasksFromManager = taskManager.getSubtasks();
+        assertNotNull(subtasksFromManager, "Subtasks list should not be null.");
+        assertEquals(1, subtasksFromManager.size(), "Expected 1 subtask in manager after creation.");
+        assertEquals("Test Subtask 1", subtasksFromManager.get(0).getName(), "Subtask name mismatch.");
+        assertEquals(epicId, subtasksFromManager.get(0).getEpicId(), "Subtask epic ID mismatch.");
+    }
+
+    @Test
+    void testUpdateSubtask() throws IOException, InterruptedException {
+        Subtask originalSubtask = new Subtask("Original Subtask", "Original Desc", TaskStatus.NEW, epicId, Duration.ofMinutes(15), LocalDateTime.now().plusHours(1));
+        int subtaskId = taskManager.createSubtask(originalSubtask);
+
+        Subtask updatedSubtask = new Subtask("Updated Subtask", "Updated Desc", subtaskId, TaskStatus.DONE, epicId, Duration.ofMinutes(45), LocalDateTime.now().plusHours(2));
+        String updatedSubtaskJson = gson.toJson(updatedSubtask);
+
+        URI url = URI.create("http://localhost:8080/subtasks");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(updatedSubtaskJson))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK for subtask update (current handler returns 200).");
+        assertTrue(response.body().contains("Подзадача с ID " + subtaskId + " обновлена."), "Response body should indicate subtask update.");
+
+        Subtask subtaskFromManager = taskManager.getSubtask(subtaskId);
+        assertNotNull(subtaskFromManager, "Updated subtask should not be null.");
+        assertEquals("Updated Subtask", subtaskFromManager.getName(), "Subtask name should be updated.");
+        assertEquals(TaskStatus.DONE, subtaskFromManager.getStatus(), "Subtask status should be updated.");
+    }
+
+    @Test
+    void testCreateSubtaskInvalidJson() throws IOException, InterruptedException {
+        String invalidJson = "{invalid json";
+
+        URI url = URI.create("http://localhost:8080/subtasks");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(invalidJson))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid JSON.");
+        assertTrue(response.body().contains("Некорректный формат JSON для подзадачи"), "Response body should indicate JSON format error.");
+    }
+
+    @Test
+    void testCreateSubtaskEmptyBody() throws IOException, InterruptedException {
+        String emptyBody = "";
+
+        URI url = URI.create("http://localhost:8080/subtasks");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(emptyBody))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for empty body.");
+        assertTrue(response.body().contains("Тело запроса пустое."), "Response body should indicate empty body error.");
+    }
+
+    @Test
+    void testCreateSubtaskForNonExistentEpic() throws IOException, InterruptedException {
+        int nonExistentEpicId = 9999;
+        Subtask subtask = new Subtask("Subtask for Non-Existent Epic", "Desc", TaskStatus.NEW, nonExistentEpicId, Duration.ofMinutes(10), LocalDateTime.now().plusDays(1));
+        String subtaskJson = gson.toJson(subtask);
+
+        URI url = URI.create("http://localhost:8080/subtasks");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(subtaskJson))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for non-existent epic ID.");
+        assertTrue(response.body().contains("Указанный Epic с ID " + nonExistentEpicId + " не существует."), "Response body should indicate non-existent epic.");
+    }
+
+    @Test
+    void testUpdateSubtaskChangeEpicId() throws IOException, InterruptedException {
+        Epic anotherEpic = new Epic("Another Epic", "Desc");
+        int anotherEpicId = taskManager.createEpic(anotherEpic);
+
+        Subtask originalSubtask = new Subtask("Subtask to Change Epic", "Original Desc", TaskStatus.NEW, epicId, Duration.ofMinutes(15), LocalDateTime.now().plusHours(3));
+        int subtaskId = taskManager.createSubtask(originalSubtask);
+
+        // Используем конструктор, который принимает ID, и пытаемся изменить epicId
+        Subtask updatedSubtask = new Subtask("Updated Subtask", "Updated Desc", subtaskId, TaskStatus.NEW, anotherEpicId, Duration.ofMinutes(15), LocalDateTime.now().plusHours(3));
+        String updatedSubtaskJson = gson.toJson(updatedSubtask);
+
+        URI url = URI.create("http://localhost:8080/subtasks");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .POST(HttpRequest.BodyPublishers.ofString(updatedSubtaskJson))
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request when changing EpicId.");
+        assertTrue(response.body().contains("Нельзя изменить EpicId у существующей подзадачи."), "Response body should indicate EpicId change is not allowed.");
+    }
+
+
+    @Test
+    void testGetAllSubtasks() throws IOException, InterruptedException {
+        taskManager.createSubtask(new Subtask("Subtask 1", "Desc 1", TaskStatus.NEW, epicId, Duration.ofMinutes(10), LocalDateTime.now().plusDays(1)));
+        taskManager.createSubtask(new Subtask("Subtask 2", "Desc 2", TaskStatus.IN_PROGRESS, epicId, Duration.ofMinutes(20), LocalDateTime.now().plusDays(2)));
+
+        URI url = URI.create("http://localhost:8080/subtasks");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK for getting all subtasks.");
+
+        List<Subtask> subtasks = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Subtask>>(){}.getType());
+
+        assertNotNull(subtasks, "Subtasks list should not be null in response.");
+        assertEquals(2, subtasks.size(), "Expected 2 subtasks in response.");
+        assertEquals("Subtask 1", subtasks.get(0).getName());
+        assertEquals("Subtask 2", subtasks.get(1).getName());
+    }
+
+    @Test
+    void testGetSubtaskByIdValid() throws IOException, InterruptedException {
+        Subtask subtask = new Subtask("Subtask for ID", "Desc for ID", TaskStatus.NEW, epicId, Duration.ofMinutes(1), LocalDateTime.now().plusHours(3));
+        int subtaskId = taskManager.createSubtask(subtask);
+
+        URI url = URI.create("http://localhost:8080/subtasks?id=" + subtaskId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK for getting subtask by ID.");
+
+        Subtask receivedSubtask = gson.fromJson(response.body(), Subtask.class);
+
+        assertNotNull(receivedSubtask, "Received subtask should not be null.");
+        assertEquals(subtaskId, receivedSubtask.getId(), "Subtask ID mismatch.");
+        assertEquals("Subtask for ID", receivedSubtask.getName(), "Subtask name mismatch.");
+    }
+
+    @Test
+    void testGetSubtaskByIdNonExistent() throws IOException, InterruptedException {
+        int nonExistentId = 999;
+        URI url = URI.create("http://localhost:8080/subtasks?id=" + nonExistentId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(404, response.statusCode(), "Expected 404 Not Found for non-existent subtask ID.");
+        assertTrue(response.body().contains("Подзадача с ID " + nonExistentId + " не найдена."), "Response body should indicate subtask not found.");
+    }
+
+    @Test
+    void testGetSubtaskByIdInvalidFormat() throws IOException, InterruptedException {
+        URI url = URI.create("http://localhost:8080/subtasks?id=abc");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid ID format (current handler logic).");
+        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+    }
+
+    @Test
+    void testDeleteSubtaskByIdValid() throws IOException, InterruptedException {
+        Subtask subtask = new Subtask("Subtask to Delete", "Desc", TaskStatus.NEW, epicId, Duration.ofMinutes(10), LocalDateTime.now().plusDays(4));
+        int subtaskId = taskManager.createSubtask(subtask);
+
+        URI url = URI.create("http://localhost:8080/subtasks?id=" + subtaskId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .DELETE()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(204, response.statusCode(), "Expected 204 No Content for successful deletion.");
+        assertNull(taskManager.getSubtask(subtaskId), "Subtask should be deleted from manager.");
+    }
+
+    @Test
+    void testDeleteSubtaskByIdNonExistent() throws IOException, InterruptedException {
+        int nonExistentId = 999;
+        URI url = URI.create("http://localhost:8080/subtasks?id=" + nonExistentId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .DELETE()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(404, response.statusCode(), "Expected 404 Not Found for deleting non-existent subtask.");
+        assertTrue(response.body().contains("Подзадача с ID " + nonExistentId + " не найдена для удаления."), "Response body should indicate subtask not found.");
+    }
+
+    @Test
+    void testDeleteSubtaskByIdInvalidFormat() throws IOException, InterruptedException {
+        URI url = URI.create("http://localhost:8080/subtasks?id=xyz");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .DELETE()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid ID format (current handler logic).");
+        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+    }
+
+    @Test
+    void testDeleteAllSubtasks() throws IOException, InterruptedException {
+        taskManager.createSubtask(new Subtask("Subtask 1", "Desc 1", TaskStatus.NEW, epicId, Duration.ofMinutes(10), LocalDateTime.now().plusDays(5)));
+        taskManager.createSubtask(new Subtask("Subtask 2", "Desc 2", TaskStatus.IN_PROGRESS, epicId, Duration.ofMinutes(20), LocalDateTime.now().plusDays(6)));
+
+        URI url = URI.create("http://localhost:8080/subtasks");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .DELETE()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(204, response.statusCode(), "Expected 204 No Content for deleting all subtasks.");
+        assertTrue(taskManager.getSubtasks().isEmpty(), "All subtasks should be deleted from manager.");
+    }
+
+    @Test
+    void testGetEpicSubtasksValidEpicId() throws IOException, InterruptedException {
+        taskManager.createSubtask(new Subtask("Subtask for Epic 1", "Desc", TaskStatus.NEW, epicId, Duration.ofMinutes(5), LocalDateTime.now().plusDays(7)));
+        taskManager.createSubtask(new Subtask("Subtask for Epic 2", "Desc", TaskStatus.IN_PROGRESS, epicId, Duration.ofMinutes(5), LocalDateTime.now().plusDays(8)));
+
+        Epic anotherEpic = new Epic("Another Epic", "Desc");
+        int anotherEpicId = taskManager.createEpic(anotherEpic);
+        taskManager.createSubtask(new Subtask("Subtask for Another Epic", "Desc", TaskStatus.NEW, anotherEpicId, Duration.ofMinutes(5), LocalDateTime.now().plusDays(9)));
+
+        URI url = URI.create("http://localhost:8080/subtasks/epic?id=" + epicId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode(), "Expected 200 OK for getting epic subtasks.");
+        List<Subtask> epicSubtasks = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Subtask>>(){}.getType());
+
+        assertNotNull(epicSubtasks, "Epic subtasks list should not be null.");
+        assertEquals(2, epicSubtasks.size(), "Expected 2 subtasks for the epic.");
+        assertEquals("Subtask for Epic 1", epicSubtasks.get(0).getName());
+        assertEquals("Subtask for Epic 2", epicSubtasks.get(1).getName());
+    }
+
+    @Test
+    void testGetEpicSubtasksNonExistentEpicId() throws IOException, InterruptedException {
+        int nonExistentEpicId = 9999;
+        URI url = URI.create("http://localhost:8080/subtasks/epic?id=" + nonExistentEpicId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(404, response.statusCode(), "Expected 404 Not Found for non-existent epic when requesting subtasks.");
+        assertTrue(response.body().contains("Эпик с ID " + nonExistentEpicId + " не найден."), "Response body should indicate epic not found.");
+    }
+
+    @Test
+    void testGetEpicSubtasksInvalidEpicIdFormat() throws IOException, InterruptedException {
+        URI url = URI.create("http://localhost:8080/subtasks/epic?id=invalid");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid epic ID format (current handler logic).");
+        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+    }
+
+    @Test
+    void testGetEpicSubtasksMissingEpicId() throws IOException, InterruptedException {
+        URI url = URI.create("http://localhost:8080/subtasks/epic");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(url)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for missing epic ID when requesting subtasks.");
+        assertTrue(response.body().contains("Требуется ID эпика для запроса подзадач."), "Response body should indicate missing epic ID.");
+    }
+}

--- a/test/java/http/HttpTaskServerSubtasksTest.java
+++ b/test/java/http/HttpTaskServerSubtasksTest.java
@@ -158,7 +158,6 @@ public class HttpTaskServerSubtasksTest {
         Subtask originalSubtask = new Subtask("Subtask to Change Epic", "Original Desc", TaskStatus.NEW, epicId, Duration.ofMinutes(15), LocalDateTime.now().plusHours(3));
         int subtaskId = taskManager.createSubtask(originalSubtask);
 
-        // Используем конструктор, который принимает ID, и пытаемся изменить epicId
         Subtask updatedSubtask = new Subtask("Updated Subtask", "Updated Desc", subtaskId, TaskStatus.NEW, anotherEpicId, Duration.ofMinutes(15), LocalDateTime.now().plusHours(3));
         String updatedSubtaskJson = gson.toJson(updatedSubtask);
 
@@ -245,8 +244,8 @@ public class HttpTaskServerSubtasksTest {
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid ID format (current handler logic).");
-        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid ID format.");
+        assertTrue(response.body().contains("Некорректный формат ID: 'abc' не является числом."), "Response body should indicate invalid ID format error.");
     }
 
     @Test
@@ -291,8 +290,8 @@ public class HttpTaskServerSubtasksTest {
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid ID format (current handler logic).");
-        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid ID format.");
+        assertTrue(response.body().contains("Некорректный формат ID: 'xyz' не является числом."), "Response body should indicate invalid ID format error.");
     }
 
     @Test
@@ -361,8 +360,8 @@ public class HttpTaskServerSubtasksTest {
                 .build();
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-        assertEquals(500, response.statusCode(), "Expected 500 Internal Server Error for invalid epic ID format (current handler logic).");
-        assertTrue(response.body().contains("Ошибка сервера: Некорректный формат ID"), "Response body should indicate server error related to ID format.");
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid epic ID format.");
+        assertTrue(response.body().contains("Некорректный формат ID: 'invalid' не является числом."), "Response body should indicate invalid ID format error.");
     }
 
     @Test

--- a/test/java/http/HttpTaskServerTasksTest.java
+++ b/test/java/http/HttpTaskServerTasksTest.java
@@ -1,0 +1,259 @@
+package http;
+
+import com.google.gson.Gson;
+import manager.InMemoryTaskManager;
+import manager.TaskManager;
+import model.Task;
+import model.TaskStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HttpTaskServerTasksTest {
+
+    TaskManager manager;
+    HttpTaskServer taskServer;
+    Gson gson;
+
+    private Task testTask;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        manager = new InMemoryTaskManager();
+        taskServer = new HttpTaskServer(manager);
+        taskServer.start();
+        gson = HttpTaskServer.getGson();
+
+        manager.removeAllTasks();
+        manager.removeAllEpics();
+        manager.removeAllSubtasks();
+
+        testTask = new Task("Test Task", "Description",
+                Duration.ofMinutes(30), LocalDateTime.now().plusHours(1));
+    }
+
+    @AfterEach
+    public void shutDown() {
+        taskServer.stop();
+    }
+
+
+    // Тесты для GET /tasks
+    @Test
+    void testGetAllTasksEmpty() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).GET().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 OK for getting empty tasks list");
+
+        List<Task> tasks = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Task>>() {}.getType());
+        assertNotNull(tasks, "Tasks list should not be null");
+        assertTrue(tasks.isEmpty(), "Tasks list should be empty");
+    }
+
+    @Test
+    void testGetAllTasks() throws IOException, InterruptedException {
+        manager.createTask(testTask);
+        Task anotherTask = new Task("Another Task", "Another Desc",
+                Duration.ofMinutes(60), LocalDateTime.now().plusHours(2));
+        manager.createTask(anotherTask);
+
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).GET().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 OK for getting all tasks");
+
+        List<Task> tasks = gson.fromJson(response.body(), new com.google.gson.reflect.TypeToken<List<Task>>() {}.getType());
+        assertNotNull(tasks, "Tasks list should not be null");
+        assertEquals(2, tasks.size(), "Expected 2 tasks");
+        assertTrue(tasks.contains(testTask), "List should contain testTask");
+        assertTrue(tasks.contains(anotherTask), "List should contain anotherTask");
+    }
+
+    @Test
+    void testGetTaskById() throws IOException, InterruptedException {
+        int taskId = manager.createTask(testTask);
+
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks?id=" + taskId);
+        HttpRequest request = HttpRequest.newBuilder().uri(url).GET().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 OK for getting task by ID");
+
+        Task receivedTask = gson.fromJson(response.body(), Task.class);
+        assertNotNull(receivedTask, "Received task should not be null");
+        assertEquals(testTask, receivedTask, "Received task should match original");
+    }
+
+    @Test
+    void testGetTaskByIdNotFound() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks?id=999");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).GET().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(404, response.statusCode(), "Expected 404 Not Found for non-existent task");
+        assertTrue(response.body().contains("не найдена"), "Response body should indicate task not found");
+    }
+
+    @Test
+    void testGetTaskByIdInvalidFormat() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks?id=abc");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).GET().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid ID format");
+    }
+
+    // Тесты для POST /tasks
+    @Test
+    void testCreateTask() throws IOException, InterruptedException {
+        Task newTask = new Task("New Task", "New Description",
+                Duration.ofMinutes(45), LocalDateTime.now().plusDays(1));
+        String taskJson = gson.toJson(newTask);
+
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).POST(HttpRequest.BodyPublishers.ofString(taskJson)).build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 OK for task creation");
+        assertTrue(response.body().contains("Задача создана с ID:"), "Response should indicate creation with ID");
+
+        List<Task> tasksFromManager = manager.getTasks();
+        assertNotNull(tasksFromManager, "Tasks list should not be null");
+        assertEquals(1, tasksFromManager.size(), "Expected 1 task in manager");
+        assertEquals(newTask.getName(), tasksFromManager.get(0).getName(), "Task name should match");
+        assertNotEquals(0, tasksFromManager.get(0).getId(), "Task ID should be assigned");
+    }
+
+    @Test
+    void testUpdateTask() throws IOException, InterruptedException {
+        int taskId = manager.createTask(testTask);
+        Task updatedTask = new Task("Updated Task", "Updated Description", taskId, TaskStatus.DONE,
+                Duration.ofMinutes(60), LocalDateTime.now().plusHours(3));
+        String taskJson = gson.toJson(updatedTask);
+
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).POST(HttpRequest.BodyPublishers.ofString(taskJson)).build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(), "Expected 200 OK for task update");
+        assertTrue(response.body().contains("обновлена"), "Response should indicate update");
+
+        Task taskFromManager = manager.getTask(taskId);
+        assertNotNull(taskFromManager, "Task should exist in manager");
+        assertEquals("Updated Task", taskFromManager.getName(), "Task name should be updated");
+        assertEquals(TaskStatus.DONE, taskFromManager.getStatus(), "Task status should be updated");
+    }
+
+    @Test
+    void testPostTaskEmptyBody() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).POST(HttpRequest.BodyPublishers.ofString("")).build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for empty body");
+        assertTrue(response.body().contains("Тело запроса пустое"), "Response should indicate empty body");
+    }
+
+    @Test
+    void testPostTaskInvalidJson() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).POST(HttpRequest.BodyPublishers.ofString("{invalid json")).build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid JSON");
+        assertTrue(response.body().contains("Некорректный формат JSON"), "Response should indicate invalid JSON");
+    }
+
+    @Test
+    void testPostTaskTimeIntersection() throws IOException, InterruptedException {
+        Task initialTask = new Task("Initial Task", "Desc",
+                Duration.ofMinutes(60), LocalDateTime.of(2025, 1, 1, 10, 0));
+        manager.createTask(initialTask);
+
+        Task intersectingTask = new Task("Intersecting Task", "Desc",
+                Duration.ofMinutes(60), LocalDateTime.of(2025, 1, 1, 10, 30));
+        String taskJson = gson.toJson(intersectingTask);
+
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).POST(HttpRequest.BodyPublishers.ofString(taskJson)).build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(406, response.statusCode(), "Expected 406 Not Acceptable for time intersection");
+        assertTrue(response.body().contains("пересечению интервалов выполнения"), "Response should indicate intersection");
+    }
+
+    // Тесты для DELETE /tasks
+    @Test
+    void testDeleteAllTasks() throws IOException, InterruptedException {
+        manager.createTask(testTask);
+        manager.createTask(new Task("Another Task", "Desc", Duration.ofMinutes(10), LocalDateTime.now().plusHours(5)));
+
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).DELETE().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(204, response.statusCode(), "Expected 204 No Content for deleting all tasks");
+
+        assertTrue(manager.getTasks().isEmpty(), "All tasks should be deleted from manager");
+    }
+
+    @Test
+    void testDeleteTaskById() throws IOException, InterruptedException {
+        int taskId = manager.createTask(testTask);
+
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks?id=" + taskId);
+        HttpRequest request = HttpRequest.newBuilder().uri(url).DELETE().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(204, response.statusCode(), "Expected 204 No Content for deleting task by ID");
+
+        assertNull(manager.getTask(taskId), "Task should be deleted from manager");
+    }
+
+    @Test
+    void testDeleteTaskByIdNotFound() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks?id=999");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).DELETE().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(404, response.statusCode(), "Expected 404 Not Found for deleting non-existent task");
+        assertTrue(response.body().contains("не найдена для удаления"), "Response body should indicate not found");
+    }
+
+    @Test
+    void testDeleteTaskByIdInvalidFormat() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        URI url = URI.create("http://localhost:8080/tasks?id=xyz");
+        HttpRequest request = HttpRequest.newBuilder().uri(url).DELETE().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode(), "Expected 400 Bad Request for invalid ID format");
+    }
+}

--- a/test/java/http/HttpTaskServerTasksTest.java
+++ b/test/java/http/HttpTaskServerTasksTest.java
@@ -22,9 +22,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpTaskServerTasksTest {
 
-    TaskManager manager;
-    HttpTaskServer taskServer;
-    Gson gson;
+    // Добавлены модификаторы доступа
+    private TaskManager manager;
+    private HttpTaskServer taskServer;
+    private Gson gson;
 
     private Task testTask;
 

--- a/test/java/manager/FileBackedTaskManagerTest.java
+++ b/test/java/manager/FileBackedTaskManagerTest.java
@@ -1,363 +1,111 @@
 package manager;
 
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
 import model.Epic;
 import model.Subtask;
 import model.Task;
 import model.TaskStatus;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Comparator;
-import java.util.stream.Stream;
+public class FileBackedTaskManagerTest extends TaskManagerTest<FileBackedTaskManager> {
+    private File tempFile;
 
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class FileBackedTaskManagerTest extends TaskManagerTest<FileBackedTaskManager> {
-
-    private Path tempFile;
+    protected TaskManager createTaskManager() {
+        try {
+            return FileBackedTaskManager.loadFromFile(this.tempFile);
+        } catch (ManagerSaveException var2) {
+            throw new RuntimeException(var2);
+        }
+    }
 
     @BeforeEach
-    @Override
     protected void setUp() {
         try {
-            tempFile = Files.createTempFile("testTasks", ".csv");
-        } catch (IOException e) {
-            throw new RuntimeException("Не удалось создать временный файл для теста", e);
+            this.tempFile = File.createTempFile("test", ".csv");
+        } catch (IOException var2) {
+            throw new RuntimeException(var2);
         }
+
         super.setUp();
     }
 
     @AfterEach
-    void tearDown() {
-        try {
-            Files.deleteIfExists(tempFile);
-        } catch (IOException e) {
-            throw new RuntimeException("Не удалось удалить временный файл после теста", e);
-        }
-    }
-
-    @Override
-    protected FileBackedTaskManager createTaskManager() {
-        try {
-            return FileBackedTaskManager.loadFromFile(tempFile.toFile());
-        } catch (ManagerSaveException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-
-    @Test
-    void saveAndLoadEmptyFile() {
-        assertTrue(taskManager.getTasks().isEmpty());
-        assertTrue(taskManager.getEpics().isEmpty());
-        assertTrue(taskManager.getSubtasks().isEmpty());
-        assertTrue(taskManager.getHistory().isEmpty());
-        assertTrue(taskManager.getPrioritizedTasks().isEmpty());
-
-        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-        assertEquals(0, loadedManager.idCounter, "idCounter должен быть 0 при загрузке пустого файла");
-    }
-
-
-    @Test
-    void saveAndLoadTasks() {
-        Task task1 = new Task("Задача 1", "Описание 1", Duration.ofMinutes(30), LocalDateTime.now());
-        taskManager.createTask(task1);
-        Task task2 = new Task("Задача 2", "Описание 2");
-        taskManager.createTask(task2);
-
-        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-
-        List<Task> loadedTasks = loadedManager.getTasks();
-        assertEquals(2, loadedTasks.size());
-
-        Task retrievedTask1 = loadedManager.getTask(task1.getId());
-        Task retrievedTask2 = loadedManager.getTask(task2.getId());
-
-        assertNotNull(retrievedTask1);
-        assertEquals(task1.getName(), retrievedTask1.getName());
-        assertEquals(task1.getDescription(), retrievedTask1.getDescription());
-        assertEquals(task1.getStatus(), retrievedTask1.getStatus());
-        assertEquals(task1.getId(), retrievedTask1.getId());
-        assertEquals(task1.getDuration(), retrievedTask1.getDuration());
-        assertEquals(task1.getStartTime(), retrievedTask1.getStartTime());
-        assertEquals(task1.getEndTime(), retrievedTask1.getEndTime());
-
-
-        assertNotNull(retrievedTask2);
-        assertEquals(task2.getName(), retrievedTask2.getName());
-        assertEquals(task2.getDescription(), retrievedTask2.getDescription());
-        assertEquals(task2.getStatus(), retrievedTask2.getStatus());
-        assertEquals(task2.getId(), retrievedTask2.getId());
-        assertNull(retrievedTask2.getDuration());
-        assertNull(retrievedTask2.getStartTime());
-        assertNull(retrievedTask2.getEndTime());
-
-
-        int maxId = Stream.of(task1.getId(), task2.getId()).max(Integer::compareTo).orElse(0);
-        assertEquals(maxId, loadedManager.idCounter, "idCounter должен быть равен максимальному ID в файле");
-
-        Task newTask = new Task("Новая задача", "Новое описание", Duration.ofMinutes(10), LocalDateTime.now().plusHours(1));
-        int newTaskId = loadedManager.createTask(newTask); // ID 3 (maxId + 1)
-        assertEquals(loadedManager.idCounter, newTaskId, "Новый ID должен быть на 1 больше idCounter после загрузки");
+    protected void tearDown() {
+        this.tempFile.delete();
     }
 
     @Test
-    void saveAndLoadEpicsAndSubtasks() {
-        Epic epic1 = new Epic("Эпик 1", "Описание эпика 1");
-        int epicId1 = taskManager.createEpic(epic1);
-
-        Subtask subtask1 = new Subtask("Подзадача 1 NEW", "Описание 1", epicId1, Duration.ofMinutes(30), LocalDateTime.now().plusHours(1));
-        int subtaskId1 = taskManager.createSubtask(subtask1);
-
-        Subtask subtask2 = new Subtask("Подзадача 2 DONE", "Описание 2", epicId1, Duration.ofMinutes(45), LocalDateTime.now().plusHours(2));
-        subtask2.setStatus(TaskStatus.DONE);
-        int subtaskId2 = taskManager.createSubtask(subtask2);
-
-        Epic originalEpic = taskManager.getEpic(epicId1);
-        assertEquals(TaskStatus.IN_PROGRESS, originalEpic.getStatus());
-        assertEquals(Duration.ofMinutes(75), originalEpic.getDuration());
-        assertNotNull(originalEpic.getStartTime());
-
-
-        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-
-        List<Epic> loadedEpics = loadedManager.getEpics();
-        assertEquals(1, loadedEpics.size());
-        Epic loadedEpic = loadedEpics.get(0);
-
-        assertEquals(epic1.getName(), loadedEpic.getName());
-        assertEquals(epic1.getDescription(), loadedEpic.getDescription());
-        assertEquals(epic1.getId(), loadedEpic.getId());
-
-        assertEquals(TaskStatus.IN_PROGRESS, loadedEpic.getStatus());
-        assertEquals(Duration.ofMinutes(75), loadedEpic.getDuration());
-        assertNotNull(loadedEpic.getStartTime());
-        assertNotNull(loadedEpic.getEndTime());
-        assertTrue(loadedEpic.getSubtaskIds().contains(subtaskId1));
-        assertTrue(loadedEpic.getSubtaskIds().contains(subtaskId2));
-
-        List<Subtask> loadedSubtasks = loadedManager.getSubtasks();
-        assertEquals(2, loadedSubtasks.size());
-
-        Subtask retrievedSubtask1 = loadedManager.getSubtask(subtaskId1);
-        assertNotNull(retrievedSubtask1);
-        assertEquals(subtask1.getName(), retrievedSubtask1.getName());
-        assertEquals(subtask1.getDescription(), retrievedSubtask1.getDescription());
-        assertEquals(subtask1.getStatus(), retrievedSubtask1.getStatus());
-        assertEquals(subtask1.getId(), retrievedSubtask1.getId());
-        assertEquals(subtask1.getEpicId(), retrievedSubtask1.getEpicId());
-        assertEquals(subtask1.getDuration(), retrievedSubtask1.getDuration());
-        assertEquals(subtask1.getStartTime(), retrievedSubtask1.getStartTime());
-
-
-        Subtask retrievedSubtask2 = loadedManager.getSubtask(subtaskId2);
-        assertNotNull(retrievedSubtask2);
-        assertEquals(subtask2.getName(), retrievedSubtask2.getName());
-        assertEquals(subtask2.getDescription(), retrievedSubtask2.getDescription());
-        assertEquals(subtask2.getStatus(), retrievedSubtask2.getStatus());
-        assertEquals(subtask2.getId(), retrievedSubtask2.getId());
-        assertEquals(subtask2.getEpicId(), retrievedSubtask2.getEpicId());
-        assertEquals(subtask2.getDuration(), retrievedSubtask2.getDuration());
-        assertEquals(subtask2.getStartTime(), retrievedSubtask2.getStartTime());
-
-        List<Task> prioritized = loadedManager.getPrioritizedTasks();
-        assertEquals(3, prioritized.size());
-        assertTrue(prioritized.contains(loadedEpic));
-        assertTrue(prioritized.contains(retrievedSubtask1));
-        assertTrue(prioritized.contains(retrievedSubtask2));
-
-        int maxId = Stream.of(epicId1, subtaskId1, subtaskId2).max(Integer::compareTo).orElse(0);
-        assertEquals(maxId, loadedManager.idCounter, "idCounter должен быть равен максимальному ID в файле");
-
-        Task newTask = new Task("Новая задача", "Новое описание", Duration.ofMinutes(10), LocalDateTime.now().plusDays(3));
-        int newTaskId = loadedManager.createTask(newTask);
-        assertEquals(loadedManager.idCounter, newTaskId, "Новый ID должен быть на 1 больше максимального после загрузки");
+    void loadEmptyFile() {
+        Assertions.assertTrue(this.taskManager.getTasks().isEmpty(), "Должен загружаться пустой список задач.");
+        Assertions.assertTrue(this.taskManager.getEpics().isEmpty(), "Должен загружаться пустой список эпиков.");
+        Assertions.assertTrue(this.taskManager.getSubtasks().isEmpty(), "Должен загружаться пустой список подзадач.");
+        Assertions.assertTrue(this.taskManager.getHistory().isEmpty(), "История должна быть пустой.");
     }
 
     @Test
-    void saveAndLoadMixedTaskTypes() {
-        Task task = new Task("Простая задача", "Описание", Duration.ofMinutes(60), LocalDateTime.now().plusHours(5));
-        taskManager.createTask(task);
-
-        Epic epic = new Epic("Большой эпик", "Описание эпика");
-        int epicId = taskManager.createEpic(epic);
-
-        Subtask subtask1 = new Subtask("Часть эпика 1", "Описание 1", epicId, Duration.ofMinutes(30), LocalDateTime.now().plusHours(1));
-        taskManager.createSubtask(subtask1);
-
-        Subtask subtask2 = new Subtask("Часть эпика 2", "Описание 2", epicId, Duration.ofMinutes(45), LocalDateTime.now().plusHours(2));
-        taskManager.createSubtask(subtask2);
-
-        List<Task> originalPrioritized = taskManager.getPrioritizedTasks();
-        assertEquals(4, originalPrioritized.size());
-
-        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-
-        assertEquals(1, loadedManager.getTasks().size());
-        assertEquals(1, loadedManager.getEpics().size());
-        assertEquals(2, loadedManager.getSubtasks().size());
-
-        List<Task> loadedPrioritized = loadedManager.getPrioritizedTasks();
-        assertEquals(4, loadedPrioritized.size(), "Должны загрузиться 4 приоритезированные задачи (Задача, Эпик, 2 Подзадачи)");
-
-        List<Task> expectedPrioritized = new ArrayList<>();
-        expectedPrioritized.add(loadedManager.getTask(task.getId()));
-        expectedPrioritized.add(loadedManager.getEpic(epicId));
-        expectedPrioritized.add(loadedManager.getSubtask(subtask1.getId()));
-        expectedPrioritized.add(loadedManager.getSubtask(subtask2.getId()));
-
-        expectedPrioritized.sort(Comparator.comparing(Task::getStartTime, Comparator.nullsLast(LocalDateTime::compareTo)).thenComparing(Task::getId));
-
-
-        assertEquals(expectedPrioritized.size(), loadedPrioritized.size());
-
-        for (int i = 0; i < expectedPrioritized.size(); i++) {
-            assertEquals(expectedPrioritized.get(i).getId(), loadedPrioritized.get(i).getId(), "Элемент " + i + " в приоритезированных списках не совпадает по ID");
-        }
-
-
-        int maxId = Stream.of(task.getId(), epicId, subtask1.getId(), subtask2.getId()).max(Integer::compareTo).orElse(0);
-        assertEquals(maxId, loadedManager.idCounter, "idCounter должен быть равен максимальному ID в файле");
-
-    }
-
-
-    @Test
-    void loadFromFile_shouldHandleCorruptedFile() {
-        assertDoesNotThrow(() -> {
-            Files.writeString(tempFile, "id,type,name,status,description,startTime,duration,epic\n" +
-                    "некорректная_строка_1\n" +
-                    "1,TASK,Корректная задача,NEW,Описание,2024-01-01T10:00,30,\n" +
-                    "2,EPIC,Корректный эпик,NEW,Описание_эпика,,,\n" +
-                    "3,SUBTASK,Подзадача без эпика,NEW,Описание_подзадачи,2024-01-01T11:00,15,999\n" +
-                    "4,TASK,Задача с неверной длительностью,NEW,Описание,2024-01-01T12:00,неверно,\n" +
-                    "5,TASK,Задача с неверным временем,NEW,Описание,неверное_время,30,\n" +
-                    "6,SUBTASK,Подзадача с неверным epicId,NEW,Описание,2024-01-01T13:00,30,неверно\n" +
-                    "некорректная_строка_2\n");
-
-
-            FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-
-            assertEquals(1, loadedManager.getTasks().size(), "Должна загрузиться 1 корректная задача");
-            assertEquals(1, loadedManager.getEpics().size(), "Должен загрузиться 1 корректный эпик");
-            assertEquals(1, loadedManager.getSubtasks().size(), "Должна загрузиться 1 подзадача с несуществующим эпиком");
-
-
-            Task correctTask = loadedManager.getTask(1);
-            assertNotNull(correctTask);
-            assertEquals("Корректная задача", correctTask.getName());
-            assertEquals(TaskStatus.NEW, correctTask.getStatus());
-            assertEquals(Duration.ofMinutes(30), correctTask.getDuration());
-            assertNotNull(correctTask.getStartTime());
-
-            Epic correctEpic = loadedManager.getEpic(2);
-            assertNotNull(correctEpic);
-            assertEquals("Корректный эпик", correctEpic.getName());
-            assertEquals(TaskStatus.NEW, correctEpic.getStatus());
-            assertTrue(correctEpic.getSubtaskIds().isEmpty(), "Эпик не должен содержать подзадачи с несуществующим epicId");
-
-
-            Subtask unlinkedSubtask = loadedManager.getSubtask(3);
-            assertNotNull(unlinkedSubtask, "Подзадача с несуществующим эпиком должна быть загружена");
-            assertEquals(999, unlinkedSubtask.getEpicId(), "Подзадача должна иметь epicId из файла");
-
-
-            List<Task> prioritized = loadedManager.getPrioritizedTasks();
-            assertEquals(2, prioritized.size(), "Корректная задача и подзадача с временем должны быть в приоритезированных");
-            assertTrue(prioritized.contains(correctTask));
-            assertTrue(prioritized.contains(unlinkedSubtask));
-
-
-            assertEquals(3, loadedManager.idCounter, "idCounter должен быть равен максимальному загруженному ID");
-
-
-        });
-
+    void saveAndLoadSingleTask() {
+        Task task = new Task("Test Task", "Test Description", Duration.ofMinutes(60L), LocalDateTime.of(2023, 1, 1, 10, 0));
+        this.taskManager.createTask(task);
+        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(this.tempFile);
+        List<Task> tasks = loadedManager.getTasks();
+        Assertions.assertFalse(tasks.isEmpty());
+        Assertions.assertEquals(1, tasks.size());
+        Assertions.assertEquals(task, tasks.get(0));
+        Assertions.assertEquals("Test Task", tasks.get(0).getName());
     }
 
     @Test
-    void loadFromFile_shouldHandleFileWithOnlyHeader() {
-        assertDoesNotThrow(() -> {
-            Files.writeString(tempFile, "id,type,name,status,description,startTime,duration,epic\n");
-
-            FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-
-            assertTrue(loadedManager.getTasks().isEmpty());
-            assertTrue(loadedManager.getEpics().isEmpty());
-            assertTrue(loadedManager.getSubtasks().isEmpty());
-            assertTrue(loadedManager.getHistory().isEmpty());
-            assertTrue(loadedManager.getPrioritizedTasks().isEmpty());
-            assertEquals(0, loadedManager.idCounter);
-        });
+    void saveAndLoadMultipleTasksAndEpicsAndSubtasks() {
+        Task task1 = new Task("Task 1", "Description 1", Duration.ofMinutes(30L), LocalDateTime.of(2023, 1, 1, 10, 0));
+        this.taskManager.createTask(task1);
+        Epic epic1 = new Epic("Epic 1", "Description 1");
+        int epicId1 = this.taskManager.createEpic(epic1);
+        Subtask subtask1 = new Subtask("Subtask 1", "Description 1", TaskStatus.NEW, epicId1, Duration.ofMinutes(15L), LocalDateTime.of(2023, 1, 1, 10, 30));
+        this.taskManager.createSubtask(subtask1);
+        Task task2 = new Task("Task 2", "Description 2");
+        this.taskManager.createTask(task2);
+        this.taskManager.getTask(task1.getId());
+        this.taskManager.getEpic(epicId1);
+        this.taskManager.getSubtask(subtask1.getId());
+        this.taskManager.getTask(task2.getId());
+        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(this.tempFile);
+        Assertions.assertEquals(2, loadedManager.getTasks().size(), "Должно быть 2 задачи.");
+        Assertions.assertEquals(1, loadedManager.getEpics().size(), "Должен быть 1 эпик.");
+        Assertions.assertEquals(1, loadedManager.getSubtasks().size(), "Должна быть 1 подзадача.");
+        Assertions.assertFalse(loadedManager.getHistory().isEmpty(), "История не должна быть пустой.");
+        Assertions.assertEquals(4, loadedManager.getHistory().size(), "В истории должно быть 4 элемента.");
     }
 
     @Test
-    void deleteTask_shouldSaveState() {
-        Task task = new Task("Задача для удаления", "Описание", Duration.ofMinutes(10), LocalDateTime.now());
-        int taskId = taskManager.createTask(task);
-
-        taskManager.deleteTask(taskId);
-
-        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-        assertTrue(loadedManager.getTasks().isEmpty(), "Задач не должно быть после удаления и загрузки");
-        assertTrue(loadedManager.getPrioritizedTasks().isEmpty(), "Приоритезированных задач не должно быть после удаления и загрузки");
-        assertEquals(0, loadedManager.idCounter, "idCounter должен быть 0 после удаления последней задачи и загрузки");
+    void saveAndLoadWithEmptyHistory() {
+        Task task = new Task("Task with no history", "Description", Duration.ofMinutes(30L), LocalDateTime.of(2023, 1, 1, 10, 0));
+        this.taskManager.createTask(task);
+        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(this.tempFile);
+        Assertions.assertTrue(loadedManager.getHistory().isEmpty(), "История должна быть пустой, если не было просмотров.");
+        Assertions.assertFalse(loadedManager.getTasks().isEmpty());
     }
 
     @Test
-    void deleteEpic_shouldSaveState() {
-        Epic epic = new Epic("Эпик для удаления", "Описание");
-        int epicId = taskManager.createEpic(epic);
-        Subtask subtask = new Subtask("Подзадача эпика для удаления", "Описание", epicId, Duration.ofMinutes(15), LocalDateTime.now());
-        int subtaskId = taskManager.createSubtask(subtask);
-
-        assertEquals(2, taskManager.getPrioritizedTasks().size());
-
-        taskManager.deleteEpic(epicId);
-
-        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-        assertTrue(loadedManager.getEpics().isEmpty(), "Эпиков не должно быть после удаления и загрузки");
-        assertTrue(loadedManager.getSubtasks().isEmpty(), "Подзадач не должно быть после удаления эпика и загрузки");
-        assertTrue(loadedManager.getPrioritizedTasks().isEmpty(), "Приоритезированных задач не должно быть после удаления эпика и загрузки");
-        assertEquals(0, loadedManager.idCounter, "idCounter должен быть 0 после удаления эпика и подзадач и загрузки");
+    void saveAndLoadWithTasksWithNoTimeAndDuration() {
+        Task task1 = new Task("Task 1", "Desc 1");
+        this.taskManager.createTask(task1);
+        Epic epic1 = new Epic("Epic 1", "Desc 1");
+        int epicId1 = this.taskManager.createEpic(epic1);
+        Subtask subtask1 = new Subtask("Subtask 1", "Desc 1", TaskStatus.NEW, epicId1, null, null);
+        this.taskManager.createSubtask(subtask1);
+        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(this.tempFile);
+        Assertions.assertEquals(1, loadedManager.getTasks().size());
+        Assertions.assertNull(((Task)loadedManager.getTasks().get(0)).getStartTime());
+        Assertions.assertEquals(1, loadedManager.getEpics().size());
+        Assertions.assertNull(((Epic)loadedManager.getEpics().get(0)).getStartTime());
+        Assertions.assertEquals(1, loadedManager.getSubtasks().size());
+        Assertions.assertNull(((Subtask)loadedManager.getSubtasks().get(0)).getStartTime());
     }
-
-    @Test
-    void deleteSubtask_shouldSaveState() {
-        Epic epic = new Epic("Эпик с подзадачей для удаления", "Описание");
-        int epicId = taskManager.createEpic(epic);
-        Subtask subtask = new Subtask("Подзадача для удаления", "Описание", epicId, Duration.ofMinutes(15), LocalDateTime.now());
-        int subtaskId = taskManager.createSubtask(subtask);
-
-        assertEquals(2, taskManager.getPrioritizedTasks().size());
-
-        taskManager.deleteSubtask(subtaskId);
-
-        FileBackedTaskManager loadedManager = FileBackedTaskManager.loadFromFile(tempFile.toFile());
-        assertEquals(1, loadedManager.getEpics().size(), "Эпик должен остаться после удаления подзадачи");
-        assertTrue(loadedManager.getSubtasks().isEmpty(), "Подзадач не должно быть после удаления");
-        assertFalse(loadedManager.getEpic(epicId).getSubtaskIds().contains(subtaskId), "Список подзадач эпика должен быть пуст");
-
-        List<Task> prioritized = loadedManager.getPrioritizedTasks();
-        assertEquals(0, prioritized.size(), "После удаления последней подзадачи со временем, эпик должен потерять время");
-
-        Epic loadedEpic = loadedManager.getEpic(epicId);
-        assertEquals(Duration.ZERO, loadedEpic.getDuration());
-        assertNull(loadedEpic.getStartTime());
-        assertNull(loadedEpic.getEndTime());
-        assertEquals(TaskStatus.NEW, loadedEpic.getStatus());
-
-        assertEquals(epicId, loadedManager.idCounter, "idCounter должен быть равен ID эпика после удаления подзадачи и загрузки");
-    }
-
 }

--- a/test/java/manager/TaskManagerTest.java
+++ b/test/java/manager/TaskManagerTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public abstract class TaskManagerTest<T extends TaskManager> {
     protected TaskManager taskManager;
 
@@ -116,8 +118,11 @@ public abstract class TaskManagerTest<T extends TaskManager> {
     @Test
     void cannotCreateSubtaskWithoutExistingEpic() {
         Subtask subtask = new Subtask("Подзадача", "Описание", TaskStatus.NEW, 10, Duration.ofMinutes(30L), LocalDateTime.now());
-        int subtaskId = this.taskManager.createSubtask(subtask);
-        Assertions.assertEquals(-1, subtaskId);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                        this.taskManager.createSubtask(subtask),
+                "Expected IllegalArgumentException when creating subtask with non-existent epic.");
+        Assertions.assertEquals("Невозможно создать подзадачу без существующего Эпика.", exception.getMessage());
     }
 
     @Test

--- a/test/java/manager/TaskManagerTest.java
+++ b/test/java/manager/TaskManagerTest.java
@@ -1,410 +1,353 @@
 package manager;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
 import model.Epic;
 import model.Subtask;
 import model.Task;
 import model.TaskStatus;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.List;
-
-
-import static org.junit.jupiter.api.Assertions.*;
-
 public abstract class TaskManagerTest<T extends TaskManager> {
-
     protected TaskManager taskManager;
+
+    public TaskManagerTest() {
+    }
 
     protected abstract TaskManager createTaskManager();
 
     @BeforeEach
     protected void setUp() {
-        taskManager = createTaskManager();
+        this.taskManager = this.createTaskManager();
     }
-
 
     @Test
     void taskManagerCreationAndInitialization() {
-        assertNotNull(taskManager);
-        assertTrue(taskManager.getTasks().isEmpty());
-        assertTrue(taskManager.getEpics().isEmpty());
-        assertTrue(taskManager.getSubtasks().isEmpty());
-        assertTrue(taskManager.getHistory().isEmpty());
-        assertTrue(taskManager.getPrioritizedTasks().isEmpty());
+        Assertions.assertNotNull(this.taskManager);
+        Assertions.assertTrue(this.taskManager.getTasks().isEmpty());
+        Assertions.assertTrue(this.taskManager.getEpics().isEmpty());
+        Assertions.assertTrue(this.taskManager.getSubtasks().isEmpty());
+        Assertions.assertTrue(this.taskManager.getHistory().isEmpty());
+        Assertions.assertTrue(this.taskManager.getPrioritizedTasks().isEmpty());
     }
-
 
     @Test
     void createTaskAndGetById() {
-        Task task = new Task("Test Task", "Test Description", Duration.ofMinutes(30), LocalDateTime.now());
-        int taskId = taskManager.createTask(task);
-        Task retrievedTask = taskManager.getTask(taskId);
-
-        assertNotNull(retrievedTask);
-        assertEquals(task, retrievedTask);
-        assertEquals("Test Task", retrievedTask.getName());
-        assertEquals("Test Description", retrievedTask.getDescription());
-        assertEquals(TaskStatus.NEW, retrievedTask.getStatus());
-        assertEquals(Duration.ofMinutes(30), retrievedTask.getDuration());
-        assertEquals(task.getStartTime(), retrievedTask.getStartTime());
-        assertNotNull(retrievedTask.getEndTime());
+        Task task = new Task("Test Task", "Test Description", Duration.ofMinutes(30L), LocalDateTime.now());
+        int taskId = this.taskManager.createTask(task);
+        Task retrievedTask = this.taskManager.getTask(taskId);
+        Assertions.assertNotNull(retrievedTask);
+        Assertions.assertEquals(task, retrievedTask);
+        Assertions.assertEquals("Test Task", retrievedTask.getName());
+        Assertions.assertEquals("Test Description", retrievedTask.getDescription());
+        Assertions.assertEquals(TaskStatus.NEW, retrievedTask.getStatus());
+        Assertions.assertEquals(Duration.ofMinutes(30L), retrievedTask.getDuration());
+        Assertions.assertEquals(task.getStartTime(), retrievedTask.getStartTime());
+        Assertions.assertNotNull(retrievedTask.getEndTime());
     }
 
     @Test
     void createTaskWithoutTimeAndDuration() {
         Task task = new Task("Task Without Time", "Description");
-        int taskId = taskManager.createTask(task);
-        Task retrievedTask = taskManager.getTask(taskId);
-
-        assertNotNull(retrievedTask);
-        assertEquals(task, retrievedTask);
-        assertNull(retrievedTask.getDuration());
-        assertNull(retrievedTask.getStartTime());
-        assertNull(retrievedTask.getEndTime());
+        int taskId = this.taskManager.createTask(task);
+        Task retrievedTask = this.taskManager.getTask(taskId);
+        Assertions.assertNotNull(retrievedTask);
+        Assertions.assertEquals(task, retrievedTask);
+        Assertions.assertNull(retrievedTask.getDuration());
+        Assertions.assertNull(retrievedTask.getStartTime());
+        Assertions.assertNull(retrievedTask.getEndTime());
     }
-
 
     @Test
     void createEpicAndGetById() {
         Epic epic = new Epic("Test Epic", "Test Description");
-        int epicId = taskManager.createEpic(epic);
-        Epic retrievedEpic = taskManager.getEpic(epicId);
-
-        assertNotNull(retrievedEpic);
-        assertEquals(epic, retrievedEpic);
-        assertEquals("Test Epic", retrievedEpic.getName());
-        assertEquals("Test Description", retrievedEpic.getDescription());
-        assertEquals(TaskStatus.NEW, retrievedEpic.getStatus());
-        assertTrue(retrievedEpic.getSubtaskIds().isEmpty());
-        assertEquals(Duration.ZERO, retrievedEpic.getDuration());
-        assertNull(retrievedEpic.getStartTime());
-        assertNull(retrievedEpic.getEndTime());
+        int epicId = this.taskManager.createEpic(epic);
+        Epic retrievedEpic = this.taskManager.getEpic(epicId);
+        Assertions.assertNotNull(retrievedEpic);
+        Assertions.assertEquals(epic, retrievedEpic);
+        Assertions.assertEquals("Test Epic", retrievedEpic.getName());
+        Assertions.assertEquals("Test Description", retrievedEpic.getDescription());
+        Assertions.assertEquals(TaskStatus.NEW, retrievedEpic.getStatus());
+        Assertions.assertTrue(retrievedEpic.getSubtaskIds().isEmpty());
+        Assertions.assertEquals(Duration.ZERO, retrievedEpic.getDuration());
+        Assertions.assertNull(retrievedEpic.getStartTime());
+        Assertions.assertNull(retrievedEpic.getEndTime());
     }
 
     @Test
     void createSubtaskAndGetById() {
         Epic epic = new Epic("Parent Epic", "Description");
-        int epicId = taskManager.createEpic(epic);
-
-        Subtask subtask = new Subtask("Test Subtask", "Test Description", epicId, Duration.ofHours(1), LocalDateTime.now().plusDays(1));
-        int subtaskId = taskManager.createSubtask(subtask);
-        Subtask retrievedSubtask = taskManager.getSubtask(subtaskId);
-
-        assertNotNull(retrievedSubtask);
-        assertEquals(subtask, retrievedSubtask);
-        assertEquals("Test Subtask", retrievedSubtask.getName());
-        assertEquals("Test Description", retrievedSubtask.getDescription());
-        assertEquals(TaskStatus.NEW, retrievedSubtask.getStatus());
-        assertEquals(epicId, retrievedSubtask.getEpicId());
-        assertEquals(Duration.ofHours(1), retrievedSubtask.getDuration());
-        assertEquals(subtask.getStartTime(), retrievedSubtask.getStartTime());
-        assertNotNull(retrievedSubtask.getEndTime());
-
-        Epic parentEpic = taskManager.getEpic(epicId);
-        assertTrue(parentEpic.getSubtaskIds().contains(subtaskId));
+        int epicId = this.taskManager.createEpic(epic);
+        Subtask subtask = new Subtask("Test Subtask", "Test Description", TaskStatus.NEW, epicId, Duration.ofHours(1L), LocalDateTime.now().plusDays(1L));
+        int subtaskId = this.taskManager.createSubtask(subtask);
+        Subtask retrievedSubtask = this.taskManager.getSubtask(subtaskId);
+        Assertions.assertNotNull(retrievedSubtask);
+        Assertions.assertEquals(subtask, retrievedSubtask);
+        Assertions.assertEquals("Test Subtask", retrievedSubtask.getName());
+        Assertions.assertEquals("Test Description", retrievedSubtask.getDescription());
+        Assertions.assertEquals(TaskStatus.NEW, retrievedSubtask.getStatus());
+        Assertions.assertEquals(epicId, retrievedSubtask.getEpicId());
+        Assertions.assertEquals(Duration.ofHours(1L), retrievedSubtask.getDuration());
+        Assertions.assertEquals(subtask.getStartTime(), retrievedSubtask.getStartTime());
+        Assertions.assertNotNull(retrievedSubtask.getEndTime());
+        Epic parentEpic = this.taskManager.getEpic(epicId);
+        Assertions.assertTrue(parentEpic.getSubtaskIds().contains(subtaskId));
     }
 
     @Test
     void createSubtaskWithoutTimeAndDuration() {
         Epic epic = new Epic("Parent Epic", "Description");
-        int epicId = taskManager.createEpic(epic);
-
-        Subtask subtask = new Subtask("Subtask Without Time", "Description", epicId);
-        int subtaskId = taskManager.createSubtask(subtask);
-        Subtask retrievedSubtask = taskManager.getSubtask(subtaskId);
-
-        assertNotNull(retrievedSubtask);
-        assertEquals(subtask, retrievedSubtask);
-        assertNull(retrievedSubtask.getDuration());
-        assertNull(retrievedSubtask.getStartTime());
-        assertNull(retrievedSubtask.getEndTime());
-
-        Epic parentEpic = taskManager.getEpic(epicId);
-        assertTrue(parentEpic.getSubtaskIds().contains(subtaskId));
+        int epicId = this.taskManager.createEpic(epic);
+        Subtask subtask = new Subtask("Subtask Without Time", "Description", TaskStatus.NEW, epicId, null, null);
+        int subtaskId = this.taskManager.createSubtask(subtask);
+        Subtask retrievedSubtask = this.taskManager.getSubtask(subtaskId);
+        Assertions.assertNotNull(retrievedSubtask);
+        Assertions.assertEquals(subtask, retrievedSubtask);
+        Assertions.assertNull(retrievedSubtask.getDuration());
+        Assertions.assertNull(retrievedSubtask.getStartTime());
+        Assertions.assertNull(retrievedSubtask.getEndTime());
+        Epic parentEpic = this.taskManager.getEpic(epicId);
+        Assertions.assertTrue(parentEpic.getSubtaskIds().contains(subtaskId));
     }
-
 
     @Test
     void cannotCreateSubtaskWithoutExistingEpic() {
-        Subtask subtask = new Subtask("Подзадача", "Описание", 10, Duration.ofMinutes(30), LocalDateTime.now());
-        int subtaskId = taskManager.createSubtask(subtask);
-        assertEquals(-1, subtaskId);
-        assertNull(taskManager.getSubtask(10));
+        Subtask subtask = new Subtask("Подзадача", "Описание", TaskStatus.NEW, 10, Duration.ofMinutes(30L), LocalDateTime.now());
+        int subtaskId = this.taskManager.createSubtask(subtask);
+        Assertions.assertEquals(-1, subtaskId);
     }
-
 
     @Test
     void updateTask() {
-        Task task = new Task("Original Task", "Original Description", Duration.ofMinutes(30), LocalDateTime.now());
-        int taskId = taskManager.createTask(task);
-
-        Task updatedTask = new Task("Updated Task", "Updated Description", taskId, TaskStatus.DONE, Duration.ofHours(1), LocalDateTime.now().plusHours(2));
-        taskManager.updateTask(updatedTask);
-        Task retrievedTask = taskManager.getTask(taskId);
-
-        assertNotNull(retrievedTask);
-        assertEquals(updatedTask, retrievedTask);
-        assertEquals("Updated Task", retrievedTask.getName());
-        assertEquals(TaskStatus.DONE, retrievedTask.getStatus());
-        assertEquals(Duration.ofHours(1), retrievedTask.getDuration());
-        assertEquals(updatedTask.getStartTime(), retrievedTask.getStartTime());
+        Task task = new Task("Original Task", "Original Description", Duration.ofMinutes(30L), LocalDateTime.now());
+        int taskId = this.taskManager.createTask(task);
+        Task updatedTask = new Task("Updated Task", "Updated Description", taskId, TaskStatus.DONE, Duration.ofHours(1L), LocalDateTime.now().plusHours(2L));
+        this.taskManager.updateTask(updatedTask);
+        Task retrievedTask = this.taskManager.getTask(taskId);
+        Assertions.assertNotNull(retrievedTask);
+        Assertions.assertEquals(updatedTask, retrievedTask);
+        Assertions.assertEquals("Updated Task", retrievedTask.getName());
+        Assertions.assertEquals(TaskStatus.DONE, retrievedTask.getStatus());
+        Assertions.assertEquals(Duration.ofHours(1L), retrievedTask.getDuration());
+        Assertions.assertEquals(updatedTask.getStartTime(), retrievedTask.getStartTime());
     }
 
     @Test
     void updateTaskTimeAndDurationToNull() {
-        Task task = new Task("Original Task", "Original Description", Duration.ofMinutes(30), LocalDateTime.now());
-        int taskId = taskManager.createTask(task);
-
-        Task updatedTask = new Task("Updated Task", "Updated Description", taskId, TaskStatus.DONE, null, null);
-        taskManager.updateTask(updatedTask);
-        Task retrievedTask = taskManager.getTask(taskId);
-
-        assertNotNull(retrievedTask);
-        assertEquals(updatedTask, retrievedTask);
-        assertNull(retrievedTask.getDuration());
-        assertNull(retrievedTask.getStartTime());
-        assertNull(retrievedTask.getEndTime());
+        Task task = new Task("Original Task", "Original Description", Duration.ofMinutes(30L), LocalDateTime.now());
+        int taskId = this.taskManager.createTask(task);
+        Task updatedTask = new Task("Updated Task", "Updated Description", taskId, TaskStatus.DONE, (Duration)null, (LocalDateTime)null);
+        this.taskManager.updateTask(updatedTask);
+        Task retrievedTask = this.taskManager.getTask(taskId);
+        Assertions.assertNotNull(retrievedTask);
+        Assertions.assertEquals(updatedTask, retrievedTask);
+        Assertions.assertNull(retrievedTask.getDuration());
+        Assertions.assertNull(retrievedTask.getStartTime());
+        Assertions.assertNull(retrievedTask.getEndTime());
     }
-
 
     @Test
     void updateEpic() {
         Epic epic = new Epic("Original Epic", "Original Description");
-        int epicId = taskManager.createEpic(epic);
-
+        int epicId = this.taskManager.createEpic(epic);
         Epic updatedEpic = new Epic("Updated Epic", "Updated Description", epicId, TaskStatus.IN_PROGRESS);
-        taskManager.updateEpic(updatedEpic);
-        Epic retrievedEpic = taskManager.getEpic(epicId);
-
-        assertNotNull(retrievedEpic);
-        assertEquals(updatedEpic.getName(), retrievedEpic.getName());
-        assertEquals(updatedEpic.getDescription(), retrievedEpic.getDescription());
-
-        assertEquals(TaskStatus.NEW, retrievedEpic.getStatus());
-
-        assertEquals(Duration.ZERO, retrievedEpic.getDuration());
-        assertNull(retrievedEpic.getStartTime());
-        assertNull(retrievedEpic.getEndTime());
-
+        this.taskManager.updateEpic(updatedEpic);
+        Epic retrievedEpic = this.taskManager.getEpic(epicId);
+        Assertions.assertNotNull(retrievedEpic);
+        Assertions.assertEquals(updatedEpic.getName(), retrievedEpic.getName());
+        Assertions.assertEquals(updatedEpic.getDescription(), retrievedEpic.getDescription());
+        Assertions.assertEquals(TaskStatus.NEW, retrievedEpic.getStatus());
+        Assertions.assertEquals(Duration.ZERO, retrievedEpic.getDuration());
+        Assertions.assertNull(retrievedEpic.getStartTime());
+        Assertions.assertNull(retrievedEpic.getEndTime());
     }
 
     @Test
     void updateSubtask() {
         Epic epic = new Epic("Parent Epic", "Description");
-        int epicId = taskManager.createEpic(epic);
-        Subtask subtask = new Subtask("Original Subtask", "Original Description", epicId, Duration.ofMinutes(30), LocalDateTime.now());
-        int subtaskId = taskManager.createSubtask(subtask);
-
-        Subtask updatedSubtask = new Subtask("Updated Subtask", "Updated Description", subtaskId, TaskStatus.DONE, epicId, Duration.ofMinutes(45), LocalDateTime.now().plusMinutes(30));
-        taskManager.updateSubtask(updatedSubtask);
-        Subtask retrievedSubtask = taskManager.getSubtask(subtaskId);
-
-        assertNotNull(retrievedSubtask);
-        assertEquals(updatedSubtask, retrievedSubtask);
-        assertEquals("Updated Subtask", retrievedSubtask.getName());
-        assertEquals(TaskStatus.DONE, retrievedSubtask.getStatus());
-        assertEquals(epicId, retrievedSubtask.getEpicId());
-        assertEquals(Duration.ofMinutes(45), retrievedSubtask.getDuration());
-        assertEquals(updatedSubtask.getStartTime(), retrievedSubtask.getStartTime());
-
-        Epic parentEpic = taskManager.getEpic(epicId);
-        assertNotNull(parentEpic.getStartTime());
-        assertNotNull(parentEpic.getDuration());
+        int epicId = this.taskManager.createEpic(epic);
+        Subtask subtask = new Subtask("Original Subtask", "Original Description", TaskStatus.NEW, epicId, Duration.ofMinutes(30L), LocalDateTime.now());
+        int subtaskId = this.taskManager.createSubtask(subtask);
+        Subtask updatedSubtask = new Subtask("Updated Subtask", "Updated Description", subtaskId, TaskStatus.DONE, epicId, Duration.ofMinutes(45L), LocalDateTime.now().plusMinutes(30L));
+        this.taskManager.updateSubtask(updatedSubtask);
+        Subtask retrievedSubtask = this.taskManager.getSubtask(subtaskId);
+        Assertions.assertNotNull(retrievedSubtask);
+        Assertions.assertEquals(updatedSubtask, retrievedSubtask);
+        Assertions.assertEquals("Updated Subtask", retrievedSubtask.getName());
+        Assertions.assertEquals(TaskStatus.DONE, retrievedSubtask.getStatus());
+        Assertions.assertEquals(epicId, retrievedSubtask.getEpicId());
+        Assertions.assertEquals(Duration.ofMinutes(45L), retrievedSubtask.getDuration());
+        Assertions.assertEquals(updatedSubtask.getStartTime(), retrievedSubtask.getStartTime());
+        Epic parentEpic = this.taskManager.getEpic(epicId);
+        Assertions.assertNotNull(parentEpic.getStartTime());
+        Assertions.assertNotNull(parentEpic.getDuration());
     }
 
     @Test
     void updateSubtaskTimeAndDurationToNull() {
         Epic epic = new Epic("Parent Epic", "Description");
-        int epicId = taskManager.createEpic(epic);
-        Subtask subtask = new Subtask("Original Subtask", "Original Description", epicId, Duration.ofMinutes(30), LocalDateTime.now());
-        int subtaskId = taskManager.createSubtask(subtask);
-
-        Subtask updatedSubtask = new Subtask("Updated Subtask", "Updated Description", subtaskId, TaskStatus.DONE, epicId, null, null);
-        taskManager.updateSubtask(updatedSubtask);
-        Subtask retrievedSubtask = taskManager.getSubtask(subtaskId);
-
-        assertNotNull(retrievedSubtask);
-        assertEquals(updatedSubtask, retrievedSubtask);
-        assertNull(retrievedSubtask.getDuration());
-        assertNull(retrievedSubtask.getStartTime());
-        assertNull(retrievedSubtask.getEndTime());
-
-        Epic parentEpic = taskManager.getEpic(epicId);
-        assertNull(parentEpic.getStartTime());
-        assertEquals(Duration.ZERO, parentEpic.getDuration());
-        assertNull(parentEpic.getEndTime());
-        assertEquals(TaskStatus.DONE, parentEpic.getStatus());
+        int epicId = this.taskManager.createEpic(epic);
+        Subtask subtask = new Subtask("Original Subtask", "Original Description", TaskStatus.NEW, epicId, Duration.ofMinutes(30L), LocalDateTime.now());
+        int subtaskId = this.taskManager.createSubtask(subtask);
+        Subtask updatedSubtask = new Subtask("Updated Subtask", "Updated Description", subtaskId, TaskStatus.DONE, epicId, (Duration)null, (LocalDateTime)null);
+        this.taskManager.updateSubtask(updatedSubtask);
+        Subtask retrievedSubtask = this.taskManager.getSubtask(subtaskId);
+        Assertions.assertNotNull(retrievedSubtask);
+        Assertions.assertEquals(updatedSubtask, retrievedSubtask);
+        Assertions.assertNull(retrievedSubtask.getDuration());
+        Assertions.assertNull(retrievedSubtask.getStartTime());
+        Assertions.assertNull(retrievedSubtask.getEndTime());
+        Epic parentEpic = this.taskManager.getEpic(epicId);
+        Assertions.assertNull(parentEpic.getStartTime());
+        Assertions.assertEquals(Duration.ZERO, parentEpic.getDuration());
+        Assertions.assertNull(parentEpic.getEndTime());
+        Assertions.assertEquals(TaskStatus.DONE, parentEpic.getStatus());
     }
-
 
     @Test
     void deleteTaskById() {
-        Task task = new Task("Test Task", "Test Description", Duration.ofMinutes(30), LocalDateTime.now());
-        int taskId = taskManager.createTask(task);
-        taskManager.deleteTask(taskId);
-
-        assertNull(taskManager.getTask(taskId));
-        assertTrue(taskManager.getTasks().isEmpty());
-        assertTrue(taskManager.getPrioritizedTasks().isEmpty());
+        Task task = new Task("Test Task", "Test Description", Duration.ofMinutes(30L), LocalDateTime.now());
+        int taskId = this.taskManager.createTask(task);
+        this.taskManager.deleteTask(taskId);
+        Assertions.assertNull(this.taskManager.getTask(taskId));
+        Assertions.assertTrue(this.taskManager.getTasks().isEmpty());
+        Assertions.assertTrue(this.taskManager.getPrioritizedTasks().isEmpty());
     }
 
     @Test
     void deleteEpicById() {
         Epic epic = new Epic("Test Epic", "Test Description");
-        int epicId = taskManager.createEpic(epic);
-        Subtask subtask1 = new Subtask("Subtask 1", "Description", epicId, Duration.ofMinutes(15), LocalDateTime.now());
-        int subtaskId1 = taskManager.createSubtask(subtask1);
-        Subtask subtask2 = new Subtask("Subtask 2", "Description", epicId, Duration.ofMinutes(15), LocalDateTime.now().plusMinutes(20));
-        int subtaskId2 = taskManager.createSubtask(subtask2);
-
-        taskManager.deleteEpic(epicId);
-
-        assertNull(taskManager.getEpic(epicId));
-        assertTrue(taskManager.getEpics().isEmpty());
-        assertNull(taskManager.getSubtask(subtaskId1));
-        assertNull(taskManager.getSubtask(subtaskId2));
-        assertTrue(taskManager.getSubtasks().isEmpty());
-        assertTrue(taskManager.getPrioritizedTasks().isEmpty());
+        int epicId = this.taskManager.createEpic(epic);
+        Subtask subtask1 = new Subtask("Subtask 1", "Description", TaskStatus.NEW, epicId, Duration.ofMinutes(15L), LocalDateTime.now());
+        int subtaskId1 = this.taskManager.createSubtask(subtask1);
+        Subtask subtask2 = new Subtask("Subtask 2", "Description", TaskStatus.NEW, epicId, Duration.ofMinutes(15L), LocalDateTime.now().plusMinutes(20L));
+        int subtaskId2 = this.taskManager.createSubtask(subtask2);
+        this.taskManager.deleteEpic(epicId);
+        Assertions.assertNull(this.taskManager.getEpic(epicId));
+        Assertions.assertTrue(this.taskManager.getEpics().isEmpty());
+        Assertions.assertNull(this.taskManager.getSubtask(subtaskId1));
+        Assertions.assertNull(this.taskManager.getSubtask(subtaskId2));
+        Assertions.assertTrue(this.taskManager.getSubtasks().isEmpty());
+        Assertions.assertTrue(this.taskManager.getPrioritizedTasks().isEmpty());
     }
 
     @Test
     void deleteSubtaskById() {
         Epic epic = new Epic("Test Epic", "Test Description");
-        int epicId = taskManager.createEpic(epic);
-        Subtask subtask1 = new Subtask("Subtask 1", "Description", epicId, Duration.ofMinutes(15), LocalDateTime.now());
-        int subtaskId1 = taskManager.createSubtask(subtask1);
-        Subtask subtask2 = new Subtask("Subtask 2", "Description", epicId, Duration.ofMinutes(15), LocalDateTime.now().plusMinutes(20));
-        int subtaskId2 = taskManager.createSubtask(subtask2);
-
-        taskManager.deleteSubtask(subtaskId1);
-
-        assertNull(taskManager.getSubtask(subtaskId1));
-        assertNotNull(taskManager.getSubtask(subtaskId2));
-        assertEquals(1, taskManager.getSubtasks().size());
-
-        Epic parentEpic = taskManager.getEpic(epicId);
-        assertNotNull(parentEpic);
-        assertFalse(parentEpic.getSubtaskIds().contains(subtaskId1));
-        assertTrue(parentEpic.getSubtaskIds().contains(subtaskId2));
-
-        assertEquals(Duration.ofMinutes(15), parentEpic.getDuration());
-        assertEquals(subtask2.getStartTime(), parentEpic.getStartTime());
-        assertEquals(subtask2.getEndTime(), parentEpic.getEndTime());
-
-        List<Task> prioritized = taskManager.getPrioritizedTasks();
-        assertEquals(2, prioritized.size());
-        assertTrue(prioritized.contains(parentEpic));
-        assertTrue(prioritized.contains(taskManager.getSubtask(subtaskId2)));
+        int epicId = this.taskManager.createEpic(epic);
+        Subtask subtask1 = new Subtask("Subtask 1", "Description", TaskStatus.NEW, epicId, Duration.ofMinutes(15L), LocalDateTime.now());
+        int subtaskId1 = this.taskManager.createSubtask(subtask1);
+        Subtask subtask2 = new Subtask("Subtask 2", "Description", TaskStatus.NEW, epicId, Duration.ofMinutes(15L), LocalDateTime.now().plusMinutes(20L));
+        int subtaskId2 = this.taskManager.createSubtask(subtask2);
+        this.taskManager.deleteSubtask(subtaskId1);
+        Assertions.assertNull(this.taskManager.getSubtask(subtaskId1));
+        Assertions.assertNotNull(this.taskManager.getSubtask(subtaskId2));
+        Assertions.assertEquals(1, this.taskManager.getSubtasks().size());
+        Epic parentEpic = this.taskManager.getEpic(epicId);
+        Assertions.assertNotNull(parentEpic);
+        Assertions.assertFalse(parentEpic.getSubtaskIds().contains(subtaskId1));
+        Assertions.assertTrue(parentEpic.getSubtaskIds().contains(subtaskId2));
+        Assertions.assertEquals(Duration.ofMinutes(15L), parentEpic.getDuration());
+        Assertions.assertEquals(subtask2.getStartTime(), parentEpic.getStartTime());
+        Assertions.assertEquals(subtask2.getEndTime(), parentEpic.getEndTime());
+        List<Task> prioritized = this.taskManager.getPrioritizedTasks();
+        Assertions.assertEquals(2, prioritized.size());
+        Assertions.assertTrue(prioritized.contains(parentEpic));
+        Assertions.assertTrue(prioritized.contains(this.taskManager.getSubtask(subtaskId2)));
     }
-
 
     @Test
     void getAllTasks() {
-        Task task1 = new Task("Task 1", "Description 1", Duration.ofMinutes(30), LocalDateTime.now());
-        int taskId1 = taskManager.createTask(task1);
+        Task task1 = new Task("Task 1", "Description 1", Duration.ofMinutes(30L), LocalDateTime.now());
+        int taskId1 = this.taskManager.createTask(task1);
         Task task2 = new Task("Task 2", "Description 2");
-        int taskId2 = taskManager.createTask(task2);
-
-        List<Task> tasks = taskManager.getTasks();
-
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
-        assertTrue(tasks.contains(taskManager.getTask(taskId1)));
-        assertTrue(tasks.contains(taskManager.getTask(taskId2)));
+        int taskId2 = this.taskManager.createTask(task2);
+        List<Task> tasks = this.taskManager.getTasks();
+        Assertions.assertNotNull(tasks);
+        Assertions.assertEquals(2, tasks.size());
+        Assertions.assertTrue(tasks.contains(this.taskManager.getTask(taskId1)));
+        Assertions.assertTrue(tasks.contains(this.taskManager.getTask(taskId2)));
     }
 
     @Test
     void getAllEpics() {
         Epic epic1 = new Epic("Epic 1", "Description 1");
-        int epicId1 = taskManager.createEpic(epic1);
+        int epicId1 = this.taskManager.createEpic(epic1);
         Epic epic2 = new Epic("Epic 2", "Description 2");
-        int epicId2 = taskManager.createEpic(epic2);
-
-        List<Epic> epics = taskManager.getEpics();
-
-        assertNotNull(epics);
-        assertEquals(2, epics.size());
-        assertTrue(epics.contains(taskManager.getEpic(epicId1)));
-        assertTrue(epics.contains(taskManager.getEpic(epicId2)));
+        int epicId2 = this.taskManager.createEpic(epic2);
+        List<Epic> epics = this.taskManager.getEpics();
+        Assertions.assertNotNull(epics);
+        Assertions.assertEquals(2, epics.size());
+        Assertions.assertTrue(epics.contains(this.taskManager.getEpic(epicId1)));
+        Assertions.assertTrue(epics.contains(this.taskManager.getEpic(epicId2)));
     }
 
     @Test
     void getAllSubtasks() {
         Epic epic = new Epic("Parent Epic", "Description");
-        int epicId = taskManager.createEpic(epic);
-        Subtask subtask1 = new Subtask("Subtask 1", "Description", epicId, Duration.ofMinutes(15), LocalDateTime.now());
-        int subtaskId1 = taskManager.createSubtask(subtask1);
-        Subtask subtask2 = new Subtask("Subtask 2", "Description", epicId);
-        int subtaskId2 = taskManager.createSubtask(subtask2);
-
-        List<Subtask> subtasks = taskManager.getSubtasks();
-
-        assertNotNull(subtasks);
-        assertEquals(2, subtasks.size());
-        assertTrue(subtasks.contains(taskManager.getSubtask(subtaskId1)));
-        assertTrue(subtasks.contains(taskManager.getSubtask(subtaskId2)));
+        int epicId = this.taskManager.createEpic(epic);
+        Subtask subtask1 = new Subtask("Subtask 1", "Description", TaskStatus.NEW, epicId, Duration.ofMinutes(15L), LocalDateTime.now());
+        int subtaskId1 = this.taskManager.createSubtask(subtask1);
+        Subtask subtask2 = new Subtask("Subtask 2", "Description", TaskStatus.NEW, epicId, null, null);
+        int subtaskId2 = this.taskManager.createSubtask(subtask2);
+        List<Subtask> subtasks = this.taskManager.getSubtasks();
+        Assertions.assertNotNull(subtasks);
+        Assertions.assertEquals(2, subtasks.size());
+        Assertions.assertTrue(subtasks.contains(this.taskManager.getSubtask(subtaskId1)));
+        Assertions.assertTrue(subtasks.contains(this.taskManager.getSubtask(subtaskId2)));
     }
 
     @Test
     void getEpicSubtasks() {
         Epic epic1 = new Epic("Epic 1", "Description 1");
-        int epicId1 = taskManager.createEpic(epic1);
+        int epicId1 = this.taskManager.createEpic(epic1);
         Epic epic2 = new Epic("Epic 2", "Description 2");
-        int epicId2 = taskManager.createEpic(epic2);
-
-        Subtask subtask1 = new Subtask("Subtask 1", "Description", epicId1);
-        int subtaskId1 = taskManager.createSubtask(subtask1);
-        Subtask subtask2 = new Subtask("Subtask 2", "Description", epicId1);
-        int subtaskId2 = taskManager.createSubtask(subtask2);
-        Subtask subtask3 = new Subtask("Subtask 3", "Description", epicId2);
-        int subtaskId3 = taskManager.createSubtask(subtask3);
-
-        List<Subtask> epic1Subtasks = taskManager.getEpicSubtasks(epicId1);
-        List<Subtask> epic2Subtasks = taskManager.getEpicSubtasks(epicId2);
-        List<Subtask> nonExistingEpicSubtasks = taskManager.getEpicSubtasks(99);
-
-        assertNotNull(epic1Subtasks);
-        assertEquals(2, epic1Subtasks.size());
-        assertTrue(epic1Subtasks.contains(taskManager.getSubtask(subtaskId1)));
-        assertTrue(epic1Subtasks.contains(taskManager.getSubtask(subtaskId2)));
-
-        assertNotNull(epic2Subtasks);
-        assertEquals(1, epic2Subtasks.size());
-        assertTrue(epic2Subtasks.contains(taskManager.getSubtask(subtaskId3)));
-
-        assertNotNull(nonExistingEpicSubtasks);
-        assertTrue(nonExistingEpicSubtasks.isEmpty());
+        int epicId2 = this.taskManager.createEpic(epic2);
+        Subtask subtask1 = new Subtask("Subtask 1", "Description", TaskStatus.NEW, epicId1, null, null);
+        int subtaskId1 = this.taskManager.createSubtask(subtask1);
+        Subtask subtask2 = new Subtask("Subtask 2", "Description", TaskStatus.NEW, epicId1, null, null);
+        int subtaskId2 = this.taskManager.createSubtask(subtask2);
+        Subtask subtask3 = new Subtask("Subtask 3", "Description", TaskStatus.NEW, epicId2, null, null);
+        int subtaskId3 = this.taskManager.createSubtask(subtask3);
+        List<Subtask> epic1Subtasks = this.taskManager.getEpicSubtasks(epicId1);
+        List<Subtask> epic2Subtasks = this.taskManager.getEpicSubtasks(epicId2);
+        List<Subtask> nonExistingEpicSubtasks = this.taskManager.getEpicSubtasks(99);
+        Assertions.assertNotNull(epic1Subtasks);
+        Assertions.assertEquals(2, epic1Subtasks.size());
+        Assertions.assertTrue(epic1Subtasks.contains(this.taskManager.getSubtask(subtaskId1)));
+        Assertions.assertTrue(epic1Subtasks.contains(this.taskManager.getSubtask(subtaskId2)));
+        Assertions.assertNotNull(epic2Subtasks);
+        Assertions.assertEquals(1, epic2Subtasks.size());
+        Assertions.assertTrue(epic2Subtasks.contains(this.taskManager.getSubtask(subtaskId3)));
+        Assertions.assertNotNull(nonExistingEpicSubtasks);
+        Assertions.assertTrue(nonExistingEpicSubtasks.isEmpty());
     }
 
     @Test
     void removeAllEpics() {
         Epic epic1 = new Epic("Epic 1", "Description 1");
-        int epicId1 = taskManager.createEpic(epic1);
-        Subtask subtask1 = new Subtask("Subtask 1", "Description", epicId1, Duration.ofMinutes(15), LocalDateTime.now());
-        int subtaskId1 = taskManager.createSubtask(subtask1);
-        Subtask subtask2 = new Subtask("Subtask 2", "Description", epicId1, Duration.ofMinutes(15), LocalDateTime.now().plusMinutes(20));
-        int subtaskId2 = taskManager.createSubtask(subtask2);
+        int epicId1 = this.taskManager.createEpic(epic1);
+        Subtask subtask1 = new Subtask("Subtask 1", "Description", TaskStatus.NEW, epicId1, Duration.ofMinutes(15L), LocalDateTime.now());
+        int subtaskId1 = this.taskManager.createSubtask(subtask1);
+        Subtask subtask2 = new Subtask("Subtask 2", "Description", TaskStatus.NEW, epicId1, Duration.ofMinutes(15L), LocalDateTime.now().plusMinutes(20L));
+        int subtaskId2 = this.taskManager.createSubtask(subtask2);
         Epic epic2 = new Epic("Epic 2", "Description 2");
-        int epicId2 = taskManager.createEpic(epic2);
-        Subtask subtask3 = new Subtask("Subtask 3", "Description", epicId2, Duration.ofMinutes(15), LocalDateTime.now().plusMinutes(40));
-        int subtaskId3 = taskManager.createSubtask(subtask3);
-
-        taskManager.getEpic(epicId1);
-        taskManager.getEpic(epicId2);
-        taskManager.getSubtask(subtaskId1);
-        taskManager.getSubtask(subtaskId2);
-        taskManager.getSubtask(subtaskId3);
-
-
-        taskManager.removeAllEpics();
-
-        assertTrue(taskManager.getEpics().isEmpty());
-        assertTrue(taskManager.getSubtasks().isEmpty());
-        assertTrue(taskManager.getHistory().isEmpty());
-        assertTrue(taskManager.getPrioritizedTasks().isEmpty());
+        int epicId2 = this.taskManager.createEpic(epic2);
+        Subtask subtask3 = new Subtask("Subtask 3", "Description", TaskStatus.NEW, epicId2, Duration.ofMinutes(15L), LocalDateTime.now().plusMinutes(40L));
+        int subtaskId3 = this.taskManager.createSubtask(subtask3);
+        this.taskManager.getEpic(epicId1);
+        this.taskManager.getEpic(epicId2);
+        this.taskManager.getSubtask(subtaskId1);
+        this.taskManager.getSubtask(subtaskId2);
+        this.taskManager.getSubtask(subtaskId3);
+        this.taskManager.removeAllEpics();
+        Assertions.assertTrue(this.taskManager.getEpics().isEmpty());
+        Assertions.assertTrue(this.taskManager.getSubtasks().isEmpty());
+        Assertions.assertTrue(this.taskManager.getHistory().isEmpty());
+        Assertions.assertTrue(this.taskManager.getPrioritizedTasks().isEmpty());
     }
 
     @Test
@@ -412,104 +355,80 @@ public abstract class TaskManagerTest<T extends TaskManager> {
         Task task1 = new Task("Task 1", "Description 1", 1, TaskStatus.NEW);
         Task task2 = new Task("Task 2", "Description 2", 2, TaskStatus.NEW);
         Epic epic1 = new Epic("Epic 1", "Description 1", 3, TaskStatus.NEW);
-        Subtask subtask1 = new Subtask("Subtask 1", "Description", 4, TaskStatus.NEW, 3);
-
+        Subtask subtask1 = new Subtask("Subtask 1", "Description", 4, TaskStatus.NEW, 3, null, null);
         HistoryManager historyManager = Managers.getDefaultHistory();
-
-
         historyManager.add(task1);
         historyManager.add(epic1);
         historyManager.add(subtask1);
         historyManager.add(task2);
         historyManager.add(task1);
-
         List<Task> history = historyManager.getHistory();
-        assertNotNull(history);
-        assertEquals(4, history.size());
-
-        assertEquals(epic1, history.get(0));
-        assertEquals(subtask1, history.get(1));
-        assertEquals(task2, history.get(2));
-        assertEquals(task1, history.get(3));
+        Assertions.assertNotNull(history);
+        Assertions.assertEquals(4, history.size());
+        Assertions.assertEquals(epic1, history.get(0));
+        Assertions.assertEquals(subtask1, history.get(1));
+        Assertions.assertEquals(task2, history.get(2));
+        Assertions.assertEquals(task1, history.get(3));
     }
 
     @Test
     void historyShouldRemoveDeletedTasks() {
         Task task1 = new Task("Task 1", "Desc 1", 1, TaskStatus.NEW);
         Task task2 = new Task("Task 2", "Desc 2", 2, TaskStatus.NEW);
-        taskManager.createTask(task1);
-        taskManager.createTask(task2);
-        taskManager.getTask(1);
-        taskManager.getTask(2);
-        assertEquals(2, taskManager.getHistory().size());
-        taskManager.deleteTask(1);
-        assertEquals(1, taskManager.getHistory().size());
-        assertEquals(2, taskManager.getHistory().get(0).getId());
-
+        this.taskManager.createTask(task1);
+        this.taskManager.createTask(task2);
+        this.taskManager.getTask(1);
+        this.taskManager.getTask(2);
+        Assertions.assertEquals(2, this.taskManager.getHistory().size());
+        this.taskManager.deleteTask(1);
+        Assertions.assertEquals(1, this.taskManager.getHistory().size());
+        Assertions.assertEquals(2, ((Task)this.taskManager.getHistory().get(0)).getId());
         Epic epic = new Epic("Epic for history delete", "desc");
-        int epicId = taskManager.createEpic(epic);
-        Subtask subtask = new Subtask("Subtask for history delete", "desc", epicId);
-        int subtaskId = taskManager.createSubtask(subtask);
-        taskManager.getEpic(epicId);
-        taskManager.getSubtask(subtaskId);
-        assertEquals(3, taskManager.getHistory().size());
-
-        taskManager.deleteEpic(epicId);
-        assertEquals(1, taskManager.getHistory().size());
-        assertEquals(2, taskManager.getHistory().get(0).getId());
-
+        int epicId = this.taskManager.createEpic(epic);
+        Subtask subtask = new Subtask("Subtask for history delete", "desc", TaskStatus.NEW, epicId, null, null);
+        int subtaskId = this.taskManager.createSubtask(subtask);
+        this.taskManager.getEpic(epicId);
+        this.taskManager.getSubtask(subtaskId);
+        Assertions.assertEquals(3, this.taskManager.getHistory().size());
+        this.taskManager.deleteEpic(epicId);
+        Assertions.assertEquals(1, this.taskManager.getHistory().size());
+        Assertions.assertEquals(2, ((Task)this.taskManager.getHistory().get(0)).getId());
     }
-
 
     @Test
     void getPrioritizedTasks_shouldReturnEmptyListWhenNoTasksWithStartTime() {
         Task task1 = new Task("Task 1", "Desc");
-        taskManager.createTask(task1);
+        this.taskManager.createTask(task1);
         Epic epic1 = new Epic("Epic 1", "Desc");
-        taskManager.createEpic(epic1);
-        Subtask subtask1 = new Subtask("Subtask 1", "Desc", epic1.getId());
-        taskManager.createSubtask(subtask1);
-
-        List<Task> prioritized = taskManager.getPrioritizedTasks();
-        assertNotNull(prioritized);
-        assertTrue(prioritized.isEmpty());
+        this.taskManager.createEpic(epic1);
+        Subtask subtask1 = new Subtask("Subtask 1", "Desc", TaskStatus.NEW, epic1.getId(), null, null);
+        this.taskManager.createSubtask(subtask1);
+        List<Task> prioritized = this.taskManager.getPrioritizedTasks();
+        Assertions.assertNotNull(prioritized);
+        Assertions.assertTrue(prioritized.isEmpty());
     }
 
     @Test
     void getPrioritizedTasks_shouldReturnTasksAndSubtasksSortedByStartTime() {
         Epic epic1 = new Epic("Epic 1", "Desc");
-        int epicId1 = taskManager.createEpic(epic1);
-
-        Task task1 = new Task("Task 1", "Desc", Duration.ofMinutes(30), LocalDateTime.of(2023, 1, 1, 11, 0));
-        int taskId1 = taskManager.createTask(task1);
-
-        Subtask subtask1 = new Subtask("Subtask 1", "Desc", epicId1, Duration.ofMinutes(15), LocalDateTime.of(2023, 1, 1, 10, 0));
-        int subtaskId1 = taskManager.createSubtask(subtask1);
-
-        Task task2 = new Task("Task 2", "Desc", Duration.ofMinutes(45), LocalDateTime.of(2023, 1, 1, 12, 0));
-        int taskId2 = taskManager.createTask(task2);
-
-        Subtask subtask2 = new Subtask("Subtask 2", "Desc", epicId1, Duration.ofMinutes(20), LocalDateTime.of(2023, 1, 1, 10, 30));
-        int subtaskId2 = taskManager.createSubtask(subtask2);
-
-
-        List<Task> prioritized = taskManager.getPrioritizedTasks();
-        assertNotNull(prioritized);
-
-
-        Epic epicAfterSubtasks = taskManager.getEpic(epicId1);
-        assertNotNull(epicAfterSubtasks.getStartTime());
-
-
-        assertEquals(5, prioritized.size());
-
-        assertEquals(epicAfterSubtasks, prioritized.get(0));
-        assertEquals(taskManager.getSubtask(subtaskId1), prioritized.get(1));
-        assertEquals(taskManager.getSubtask(subtaskId2), prioritized.get(2));
-        assertEquals(taskManager.getTask(taskId1), prioritized.get(3));
-        assertEquals(taskManager.getTask(taskId2), prioritized.get(4));
-
-
+        int epicId1 = this.taskManager.createEpic(epic1);
+        Task task1 = new Task("Task 1", "Desc", Duration.ofMinutes(30L), LocalDateTime.of(2023, 1, 1, 11, 0));
+        int taskId1 = this.taskManager.createTask(task1);
+        Subtask subtask1 = new Subtask("Subtask 1", "Desc", TaskStatus.NEW, epicId1, Duration.ofMinutes(15L), LocalDateTime.of(2023, 1, 1, 10, 0));
+        int subtaskId1 = this.taskManager.createSubtask(subtask1);
+        Task task2 = new Task("Task 2", "Desc", Duration.ofMinutes(45L), LocalDateTime.of(2023, 1, 1, 12, 0));
+        int taskId2 = this.taskManager.createTask(task2);
+        Subtask subtask2 = new Subtask("Subtask 2", "Desc", TaskStatus.NEW, epicId1, Duration.ofMinutes(20L), LocalDateTime.of(2023, 1, 1, 10, 30));
+        int subtaskId2 = this.taskManager.createSubtask(subtask2);
+        List<Task> prioritized = this.taskManager.getPrioritizedTasks();
+        Assertions.assertNotNull(prioritized);
+        Epic epicAfterSubtasks = this.taskManager.getEpic(epicId1);
+        Assertions.assertNotNull(epicAfterSubtasks.getStartTime());
+        Assertions.assertEquals(5, prioritized.size());
+        Assertions.assertEquals(epicAfterSubtasks, prioritized.get(0));
+        Assertions.assertEquals(this.taskManager.getSubtask(subtaskId1), prioritized.get(1));
+        Assertions.assertEquals(this.taskManager.getSubtask(subtaskId2), prioritized.get(2));
+        Assertions.assertEquals(this.taskManager.getTask(taskId1), prioritized.get(3));
+        Assertions.assertEquals(this.taskManager.getTask(taskId2), prioritized.get(4));
     }
-
 }

--- a/test/java/model/SubtaskTest.java
+++ b/test/java/model/SubtaskTest.java
@@ -1,5 +1,6 @@
 package model;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -8,18 +9,18 @@ public class SubtaskTest {
 
     @Test
     void equals_shouldReturnTrue_whenSubtasksHaveSameId() {
-        Subtask subtask1 = new Subtask("Subtask1", "Description1", 1, TaskStatus.NEW, 10);
-        Subtask subtask2 = new Subtask("Subtask2", "Description2", 1, TaskStatus.NEW, 20);
-
-        assertEquals(subtask1, subtask2, "Подзадачи с одинаковым ID должны быть равны.");
+        // Добавлены null для duration и startTime, чтобы соответствовать измененному конструктору из-за Gson
+        Subtask subtask1 = new Subtask("Subtask1", "Description1", 1, TaskStatus.NEW, 10, null, null);
+        Subtask subtask2 = new Subtask("Subtask2", "Description2", 1, TaskStatus.NEW, 20, null, null);
+        Assertions.assertEquals(subtask1, subtask2, "Подзадачи с одинаковым ID должны быть равны.");
     }
 
     @Test
     void equals_shouldReturnFalse_whenSubtasksHaveDifferentId() {
-        Subtask subtask1 = new Subtask("Subtask1", "Description1", 1, TaskStatus.NEW, 10);
-        Subtask subtask2 = new Subtask("Subtask2", "Description2", 2, TaskStatus.NEW, 10);
-
-        assertNotEquals(subtask1, subtask2, "Подзадачи с разными ID не должны быть равны.");
+        // Аналогично
+        Subtask subtask1 = new Subtask("Subtask1", "Description1", 1, TaskStatus.NEW, 10, null, null);
+        Subtask subtask2 = new Subtask("Subtask2", "Description2", 2, TaskStatus.NEW, 10, null, null);
+        Assertions.assertNotEquals(subtask1, subtask2, "Подзадачи с разными ID не должны быть равны.");
     }
 
 }


### PR DESCRIPTION
Привет! Пожалуй, самое интересное ТЗ за все спринты. Впервые не хотелось умереть. 

Итак, что сделано: 
* Реализован HTTP-сервер для TaskManager;
* Добавлены обработчики для задач, эпиков, подзадач и истории;
* Эндпоинты /tasks, /epics, /subtasks, /subtasks/epic и /history полностью функциональны, поддерживают GET, POST, DELETE запросы с корректными HTTP-статусами; 
* Исправлена ошибка в методе удаления эпика, которая приводила к некорректной работе. Ошибка NullPointerException заставляла дёргаться мой глаз...
* Добавлен пакет для адаптеров, чтобы уменьшить дублирование кода;

* Снова падали тесты из-за логики работы... Исправила загрузку и сохранение истории в FileBackedTaskManager. 
* Добавлены тесты для всех эндпоинтов HTTP Task Server (Tasks, Epics, Subtasks, History).